### PR TITLE
docs: add boilerplate policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,59 @@
 
 Collection of project boilerplates.
 
+## Principles
+
+1. **Minimal**: 必要最低限のファイルのみ。過剰な設定は追加しない
+2. **Modern**: 各言語の最新ツール・ベストプラクティスを採用
+3. **CI-first**: GitHub Actionsで品質チェック。ローカルフック不要
+4. **Test-ready**: テスト環境セットアップ済み。80%カバレッジ目標
+5. **SQLite-first** (Web): 開発・テスト環境はSQLiteを使用。本番DBへの移行は利用者判断
+
+## Standard Structure
+
+```
+<boilerplate>/
+├── Makefile          # install, lint, test, clean
+├── .github/
+│   └── workflows/    # CI設定
+├── README.md         # セットアップ手順
+├── src/ or cmd/      # ソースコード
+└── tests/            # テストコード
+```
+
+## Naming Convention
+
+```
+{language}-{type}
+```
+
+| Type | Description |
+|------|-------------|
+| cli | コマンドラインツール |
+| web | Web API / Webアプリ |
+
+## Quality Gates (CI)
+
+| Check | Python | Go |
+|-------|--------|-----|
+| Linting | ruff | golangci-lint |
+| Type checking | mypy | Go標準 |
+| Tests + Coverage | pytest --cov (80%+) | go test -cover (80%+) |
+
 ## Available Boilerplates
 
 | Name | Description |
 |------|-------------|
 | [python-cli](./python-cli) | Python CLI with Typer, ruff, mypy, pytest |
+
+## Roadmap
+
+| Priority | Template | Status |
+|----------|----------|--------|
+| - | python-cli | Done |
+| Next | go-cli | Planned |
+| Future | python-web | Planned |
+| Future | go-web | Planned |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Principles セクション追加 (Minimal, Modern, CI-first, Test-ready, SQLite-first)
- Standard Structure セクション追加
- Naming Convention セクション追加
- Quality Gates (CI) セクション追加
- Roadmap セクション追加

## Related Issue

Closes #2

## Test plan

- [ ] README.md の表示確認
- [ ] 方針内容の最終確認