### PR TITLE
feat(python-cli): migrate from pip to uv

### DIFF
--- a/python-cli/.github/workflows/ci.yml
+++ b/python-cli/.github/workflows/ci.yml
@@ -16,24 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv sync --all-extras
 
       - name: Lint
-        run: |
-          ruff check .
+        run: uv run ruff check .
 
       - name: Type check
-        run: |
-          mypy src/
+        run: uv run mypy src/
 
       - name: Test
-        run: |
-          PYTHONPATH=src pytest --cov=src/mycli --cov-report=term-missing
+        run: uv run pytest --cov=src/mycli --cov-report=term-missing

--- a/python-cli/Makefile
+++ b/python-cli/Makefile
@@ -1,44 +1,37 @@
 .PHONY: install lint typecheck format test test-cov cov-html cov-open run clean clean-all help
 
-VENV := .venv
-PYTHON := $(VENV)/bin/python
-PIP := $(VENV)/bin/pip
-
-## install: Create venv and install dependencies
+## install: Install dependencies with uv
 install:
-	python3 -m venv $(VENV)
-	$(PIP) install --upgrade pip
-	$(PIP) install -r requirements.txt
+	uv sync --all-extras
 
 ## run: Run CLI (usage: make run ARGS="hello World")
 run:
-	PYTHONPATH=src $(PYTHON) -m mycli.cli $(ARGS)
+	uv run mycli $(ARGS)
 
-## lint: Run ruff and pylint
+## lint: Run ruff linter
 lint:
-	$(VENV)/bin/ruff check .
-	$(VENV)/bin/pylint src/ --fail-under=8.0 || true
+	uv run ruff check .
 
 ## typecheck: Run mypy type checking
 typecheck:
-	$(VENV)/bin/mypy src/
+	uv run mypy src/
 
 ## format: Format code with ruff
 format:
-	$(VENV)/bin/ruff format .
-	$(VENV)/bin/ruff check --fix .
+	uv run ruff format .
+	uv run ruff check --fix .
 
 ## test: Run tests
 test:
-	PYTHONPATH=src $(VENV)/bin/pytest
+	uv run pytest
 
 ## test-cov: Run tests with coverage (terminal output)
 test-cov:
-	PYTHONPATH=src $(VENV)/bin/pytest --cov=src/mycli --cov-report=term-missing --cov-fail-under=80
+	uv run pytest --cov=src/mycli --cov-report=term-missing --cov-fail-under=80
 
 ## cov-html: Generate HTML coverage report
 cov-html:
-	PYTHONPATH=src $(VENV)/bin/pytest --cov=src/mycli --cov-report=html --cov-report=term
+	uv run pytest --cov=src/mycli --cov-report=html --cov-report=term
 	@echo "Coverage report: htmlcov/index.html"
 
 ## cov-open: Generate and open HTML coverage report
@@ -54,7 +47,7 @@ clean:
 
 ## clean-all: Remove everything including venv
 clean-all: clean
-	rm -rf $(VENV)
+	rm -rf .venv
 
 ## help: Show this help
 help:

--- a/python-cli/README.md
+++ b/python-cli/README.md
@@ -1,13 +1,18 @@
 # Python CLI Boilerplate
 
-Typer + ruff + mypy + pytest のPython CLIボイラープレート。
+uv + Typer + ruff + mypy + pytest のPython CLIボイラープレート。
 
 ## Features
 
+- **Package Manager**: [uv](https://docs.astral.sh/uv/) (10-100x faster than pip)
 - **CLI**: [Typer](https://typer.tiangolo.com/)
-- **Linter**: [ruff](https://docs.astral.sh/ruff/) + pylint
+- **Linter**: [ruff](https://docs.astral.sh/ruff/)
 - **Type Checker**: [mypy](https://mypy-lang.org/) (strict mode)
 - **Testing**: [pytest](https://pytest.org/) + coverage
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ## Quick Start
 
@@ -26,9 +31,9 @@ make test
 
 ```bash
 make help        # Show all commands
-make install     # Create venv and install dependencies
+make install     # Install dependencies with uv
 make run         # Run CLI
-make lint        # Run ruff and pylint
+make lint        # Run ruff
 make typecheck   # Run mypy
 make format      # Format code
 make test        # Run tests
@@ -47,7 +52,6 @@ python-cli/
 │   └── test_cli.py
 ├── Makefile
 ├── pyproject.toml
-├── requirements.txt
 └── README.md
 ```
 

--- a/python-cli/pyproject.toml
+++ b/python-cli/pyproject.toml
@@ -6,6 +6,20 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}
 keywords = ["cli", "boilerplate", "typer"]
+dependencies = [
+    "typer>=0.9.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.1.0",
+    "mypy>=1.7.0",
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+]
+
+[project.scripts]
+mycli = "mycli.cli:app"
 
 [tool.ruff]
 target-version = "py311"

--- a/python-cli/requirements.txt
+++ b/python-cli/requirements.txt
@@ -1,6 +1,0 @@
-typer>=0.9.0
-ruff>=0.1.0
-pylint>=3.0.0
-mypy>=1.7.0
-pytest>=7.4.0
-pytest-cov>=4.1.0


### PR DESCRIPTION
## Summary

- pip + requirements.txt から uv + pyproject.toml へ移行
- Makefile を uv コマンドに更新
- CI を astral-sh/setup-uv@v5 に更新
- README に uv の前提条件を追加

## Changes

| Before | After |
|--------|-------|
| `pip install -r requirements.txt` | `uv sync --all-extras` |
| `.venv/bin/python -m mycli` | `uv run mycli` |
| `requirements.txt` | `pyproject.toml [project.dependencies]` |

## Related Issue

Closes #3

## Test plan

- [ ] `make install` が正常に動作する
- [ ] `make run ARGS="hello World"` が正常に動作する
- [ ] `make lint` が正常に動作する
- [ ] `make test` が正常に動作する
- [ ] CI が通る