### PR TITLE
chore(python-cli): simplify Makefile and remove pylint

### DIFF
--- a/python-cli/Makefile
+++ b/python-cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck format test test-cov cov-html cov-open run clean clean-all help
+.PHONY: install lint typecheck format test test-cov check ci run clean clean-all help
 
 ## install: Install dependencies with uv
 install:
@@ -25,22 +25,19 @@ format:
 test:
 	uv run pytest
 
-## test-cov: Run tests with coverage (terminal output)
+## test-cov: Run tests with coverage
 test-cov:
-	uv run pytest --cov=src/mycli --cov-report=term-missing --cov-fail-under=80
+	uv run pytest --cov=src/mycli --cov-report=term-missing
 
-## cov-html: Generate HTML coverage report
-cov-html:
-	uv run pytest --cov=src/mycli --cov-report=html --cov-report=term
-	@echo "Coverage report: htmlcov/index.html"
+## check: Run lint + typecheck
+check: lint typecheck
 
-## cov-open: Generate and open HTML coverage report
-cov-open: cov-html
-	xdg-open htmlcov/index.html 2>/dev/null || open htmlcov/index.html 2>/dev/null || echo "Open htmlcov/index.html in browser"
+## ci: Run all checks (lint + typecheck + test-cov)
+ci: lint typecheck test-cov
 
 ## clean: Remove build artifacts and cache
 clean:
-	rm -rf __pycache__ .pytest_cache .ruff_cache .mypy_cache htmlcov .coverage coverage.xml
+	rm -rf __pycache__ .pytest_cache .ruff_cache .mypy_cache .coverage coverage.xml
 	rm -rf *.egg-info src/*.egg-info build dist
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete 2>/dev/null || true

--- a/python-cli/README.md
+++ b/python-cli/README.md
@@ -38,6 +38,8 @@ make typecheck   # Run mypy
 make format      # Format code
 make test        # Run tests
 make test-cov    # Run tests with coverage
+make check       # Run lint + typecheck
+make ci          # Run all checks (lint + typecheck + test-cov)
 ```
 
 ## Project Structure

--- a/python-cli/pyproject.toml
+++ b/python-cli/pyproject.toml
@@ -54,22 +54,6 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 
-[tool.pylint.main]
-py-version = "3.11"
-jobs = 0
-load-plugins = []
-
-[tool.pylint.messages_control]
-disable = [
-    "missing-module-docstring",
-    "missing-class-docstring",
-    "missing-function-docstring",
-    "too-few-public-methods",
-]
-
-[tool.pylint.format]
-max-line-length = 88
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
@@ -81,6 +65,7 @@ branch = true
 relative_files = true
 
 [tool.coverage.report]
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.:",


### PR DESCRIPTION
## Summary

- cov-html / cov-open ターゲット削除（CLIプロジェクトに不要）
- pylint設定削除（ruffのPLルールでカバー）
- check ターゲット追加（lint + typecheck）
- ci ターゲット追加（lint + typecheck + test-cov）
- fail_under=80 を pyproject.toml に移動
- clean から htmlcov 削除

## Changes

| Before | After |
|--------|-------|
| `make test-cov` (with --cov-fail-under) | `make test-cov` (fail_under in pyproject.toml) |
| pylint + ruff | ruff only (PL rules) |
| - | `make check` (quick validation) |
| - | `make ci` (full CI check) |

## Related Issue

Closes #1

## Test plan

- [ ] `make check` が正常に動作する
- [ ] `make ci` が正常に動作する
- [ ] `make test-cov` がカバレッジ80%未満で失敗する