### PR TITLE
chore: サブプロジェクトの .claude フォルダを共通化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code
-.claude/
+.claude
+**/.claude
 
 # Coverage
 coverage.out


### PR DESCRIPTION
## Summary

- 各サブフォルダに `.claude -> ../.claude` のシンボリックリンクを作成
- `.gitignore` を更新してシンボリックリンクを除外

## 対象フォルダ

- go-cli
- go-graphql-api
- go-grpc-api
- go-rest-api
- go-ssr-web
- python-cli
- react-spa
- rust-cli

## 効果

- 設定・ログが `/home/takuya/projects/my-boilerplate/.claude/` に一元化
- サブフォルダで Claude Code を使用しても個別に `.claude/` が作成されない

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)