### PR TITLE
chore: devサーバー管理の統一（stop/status/ポート規約）

### DIFF
--- a/.github/workflows/check-makefile.yml
+++ b/.github/workflows/check-makefile.yml
@@ -1,0 +1,23 @@
+name: Check Makefile Targets
+
+on:
+  pull_request:
+    paths:
+      - "*/Makefile"
+      - "Makefile"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check server Makefiles for stop/status targets
+        run: |
+          SERVERS="go-rest-api go-graphql-api go-grpc-api go-ssr-web react-spa"
+          for dir in $SERVERS; do
+            if [ -f "$dir/Makefile" ]; then
+              grep -q "^stop:" "$dir/Makefile" || echo "::warning file=$dir/Makefile::Missing 'stop' target"
+              grep -q "^status:" "$dir/Makefile" || echo "::warning file=$dir/Makefile::Missing 'status' target"
+            fi
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: stop-all status help
+
+# Server projects (excludes CLI tools)
+SERVERS := go-rest-api go-graphql-api go-grpc-api go-ssr-web react-spa
+
+## stop-all: Stop all dev servers
+stop-all:
+	@for svc in $(SERVERS); do $(MAKE) -s -C $$svc stop 2>/dev/null || true; done
+	@echo "All servers stopped"
+
+## status: Check all dev servers
+status:
+	@for svc in $(SERVERS); do $(MAKE) -s -C $$svc status 2>/dev/null || true; done
+
+## help: Show this help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'

--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ Collection of project boilerplates.
 | Next | python-web | Planned |
 | Future | go-web | Planned |
 
+## Dev Server Management
+
+```bash
+# Check all servers
+make status
+
+# Stop all servers
+make stop-all
+```
+
+### Port Convention
+
+| Project | Port | Usage |
+|---------|------|-------|
+| go-rest-api | 8080 | REST API |
+| go-graphql-api | 8081 | GraphQL API |
+| go-grpc-api | 50051 | gRPC |
+| go-ssr-web | 8082 | SSR Web |
+| react-spa | 5173 | Vite dev |
+
+### New Project Checklist
+
+When adding a new server project:
+- [ ] Add `PORT`, `stop`, `status` targets to Makefile
+- [ ] Add to `SERVERS` in root Makefile
+- [ ] Update port convention table above
+
 ## Usage
 
 ```bash

--- a/go-graphql-api/Makefile
+++ b/go-graphql-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run lint test test-cov check ci generate clean help
+.PHONY: install build run stop status lint test test-cov check ci generate clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -7,6 +7,7 @@
 BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
+PORT ?= 8081
 
 ## install: Download dependencies
 install:
@@ -19,6 +20,14 @@ build:
 ## run: Run the server
 run:
 	go run ./cmd/server
+
+## stop: Stop the server
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+## status: Check if server is running
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "go-graphql-api: running (:$(PORT))" || echo "go-graphql-api: stopped"
 
 ## lint: Run golangci-lint
 lint:

--- a/go-grpc-api/Makefile
+++ b/go-grpc-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run lint test test-cov check ci clean generate help
+.PHONY: install build run stop status lint test test-cov check ci clean generate help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -7,6 +7,7 @@
 BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
+PORT ?= 50051
 
 ## install: Download dependencies
 install:
@@ -23,6 +24,14 @@ build:
 ## run: Run the server
 run:
 	go run ./cmd/server
+
+## stop: Stop the server
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+## status: Check if server is running
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "go-grpc-api: running (:$(PORT))" || echo "go-grpc-api: stopped"
 
 ## lint: Run golangci-lint
 lint:

--- a/go-rest-api/Makefile
+++ b/go-rest-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run lint test test-cov check ci clean help
+.PHONY: install build run stop status lint test test-cov check ci clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -7,6 +7,7 @@
 BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
+PORT ?= 8080
 
 ## install: Download dependencies
 install:
@@ -19,6 +20,14 @@ build:
 ## run: Run the server
 run:
 	go run ./cmd/server
+
+## stop: Stop the server
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+## status: Check if server is running
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "go-rest-api: running (:$(PORT))" || echo "go-rest-api: stopped"
 
 ## lint: Run golangci-lint
 lint:

--- a/go-ssr-web/Makefile
+++ b/go-ssr-web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run lint test test-cov check ci clean help
+.PHONY: install build run stop status lint test test-cov check ci clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -7,6 +7,7 @@
 BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
+PORT ?= 8082
 
 ## install: Download dependencies
 install:
@@ -19,6 +20,14 @@ build:
 ## run: Run the server
 run:
 	go run ./cmd/server
+
+## stop: Stop the server
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+## status: Check if server is running
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "go-ssr-web: running (:$(PORT))" || echo "go-ssr-web: stopped"
 
 ## lint: Run golangci-lint
 lint:

--- a/react-spa/Makefile
+++ b/react-spa/Makefile
@@ -1,4 +1,7 @@
-.PHONY: dev build preview lint format test test-watch test-coverage clean
+.PHONY: dev build preview stop status lint format test test-watch test-coverage clean
+
+# Variables
+PORT ?= 5173
 
 dev:
 	npm run dev
@@ -8,6 +11,12 @@ build:
 
 preview:
 	npm run preview
+
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "react-spa: running (:$(PORT))" || echo "react-spa: stopped"
 
 lint:
 	npm run lint


### PR DESCRIPTION
## Summary

- 各サーバープロジェクトに `PORT`, `stop`, `status` ターゲットを追加
- ルート Makefile で `stop-all`, `status` を提供
- CIでMakefileターゲット存在チェック
- README.md にポート規約を記載

## ポート規約

| Project | Port |
|---------|------|
| go-rest-api | 8080 |
| go-graphql-api | 8081 |
| go-grpc-api | 50051 |
| go-ssr-web | 8082 |
| react-spa | 5173 |

## 使い方

```bash
# 全サーバーの状態確認
make status

# 全サーバー停止
make stop-all

# 個別停止
cd go-rest-api && make stop
```

## Test plan

- [x] `make status` - 動作確認済み
- [x] `make stop-all` - 動作確認済み

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)