### PR TITLE
feat: テンプレートから単体プロジェクトを生成する scaffold コマンドの追加

### DIFF
--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -1,0 +1,145 @@
+name: Scaffold Verify
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/scaffold/**'
+      - 'go-rest-api/**'
+      - 'go-graphql-api/**'
+      - 'go-grpc-api/**'
+      - 'go-ssr-web/**'
+      - 'go-cli/**'
+      - 'react-spa/**'
+      - 'react-spa-graphql/**'
+      - 'react-spa-cloudflare/**'
+      - 'python-cli/**'
+      - 'rust-cli/**'
+      - '.github/workflows/scaffold-verify.yml'
+  pull_request:
+    paths:
+      - 'scripts/scaffold/**'
+      - 'go-rest-api/**'
+      - 'go-graphql-api/**'
+      - 'go-grpc-api/**'
+      - 'go-ssr-web/**'
+      - 'go-cli/**'
+      - 'react-spa/**'
+      - 'react-spa-graphql/**'
+      - 'react-spa-cloudflare/**'
+      - 'python-cli/**'
+      - 'rust-cli/**'
+      - '.github/workflows/scaffold-verify.yml'
+
+jobs:
+  scaffold-go:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - go-rest-api
+          - go-graphql-api
+          - go-grpc-api
+          - go-ssr-web
+          - go-cli
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: Scaffold project
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=${{ matrix.template }} \
+            dest=/tmp/test-${{ matrix.template }} \
+            name=test-${{ matrix.template }} \
+            module=github.com/test/test-${{ matrix.template }}
+
+      - name: Verify scaffolded project
+        working-directory: /tmp/test-${{ matrix.template }}
+        run: |
+          go mod tidy
+          make ci
+
+  scaffold-react:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - react-spa
+          - react-spa-graphql
+          - react-spa-cloudflare
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Scaffold project
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=${{ matrix.template }} \
+            dest=/tmp/test-${{ matrix.template }} \
+            name=test-${{ matrix.template }}
+
+      - name: Verify scaffolded project
+        working-directory: /tmp/test-${{ matrix.template }}
+        run: |
+          npm install
+          make ci
+
+  scaffold-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Scaffold project
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=python-cli \
+            dest=/tmp/test-python-cli \
+            name=test-python-cli
+
+      - name: Verify scaffolded project
+        working-directory: /tmp/test-python-cli
+        run: |
+          uv sync --all-extras
+          make ci
+
+  scaffold-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Scaffold project
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=rust-cli \
+            dest=/tmp/test-rust-cli \
+            name=test-rust-cli
+
+      - name: Verify scaffolded project
+        working-directory: /tmp/test-rust-cli
+        run: |
+          make ci

--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
       - name: Scaffold project
         run: |
           bash scripts/scaffold/scaffold.sh \
@@ -93,7 +96,7 @@ jobs:
         working-directory: /tmp/test-${{ matrix.template }}
         run: |
           npm install
-          make ci
+          make lint format-check test-coverage build
 
   scaffold-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -52,7 +52,7 @@ jobs:
           go-version: "1.25"
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
 
       - name: Scaffold project
         run: |

--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -52,7 +52,7 @@ jobs:
           go-version: "1.25"
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.2
 
       - name: Scaffold project
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: stop-all status e2e e2e-install help
+.PHONY: stop-all status e2e e2e-install scaffold help
 
 # Server projects (excludes CLI tools)
 SERVERS := go-rest-api go-graphql-api go-grpc-api go-ssr-web react-spa
@@ -19,6 +19,11 @@ e2e-install:
 ## e2e: Run E2E integration tests (starts servers automatically)
 e2e:
 	cd e2e && npx playwright test
+
+## scaffold: Generate standalone project from template (template= dest= name= [module=])
+scaffold:
+	@bash scripts/scaffold/scaffold.sh \
+		template='$(template)' dest='$(dest)' name='$(name)' module='$(module)'
 
 ## help: Show this help
 help:

--- a/scripts/scaffold/lib/ci.sh
+++ b/scripts/scaffold/lib/ci.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# CI workflow transformation - strips monorepo-specific configuration
+
+transform_ci_workflows() {
+  local dest="$1"
+  local repo_root="$2"
+  local template="$3"
+  local name="$4"
+
+  mkdir -p "$dest/.github/workflows"
+
+  # Transform CI workflow
+  local ci_src="$repo_root/.github/workflows/${template}.yml"
+  if [[ -f "$ci_src" ]]; then
+    transform_workflow "$ci_src" "$dest/.github/workflows/ci.yml" "$template" "$name"
+    info "Created CI workflow: .github/workflows/ci.yml"
+  else
+    warn "No CI workflow found: $ci_src"
+  fi
+
+  # Transform deploy workflow if it exists
+  local deploy_src="$repo_root/.github/workflows/${template}-deploy.yml"
+  if [[ -f "$deploy_src" ]]; then
+    transform_workflow "$deploy_src" "$dest/.github/workflows/deploy.yml" "$template" "$name"
+    info "Created deploy workflow: .github/workflows/deploy.yml"
+  fi
+}
+
+transform_workflow() {
+  local src="$1"
+  local dest_file="$2"
+  local template="$3"
+  local name="$4"
+
+  awk -v template="$template" -v name="$name" '
+  BEGIN {
+    in_paths = 0
+    in_defaults = 0
+  }
+
+  # Replace workflow name
+  /^name:/ {
+    gsub(template, name)
+    print
+    next
+  }
+
+  # Remove paths: block and its items
+  /^    paths:/ {
+    in_paths = 1
+    next
+  }
+  in_paths && /^      - / {
+    next
+  }
+  in_paths && !/^      - / {
+    in_paths = 0
+  }
+
+  # Remove defaults: run: working-directory: block (3-line block)
+  /^defaults:/ {
+    in_defaults = 1
+    defaults_depth = 0
+    next
+  }
+  in_defaults && /^  run:/ {
+    next
+  }
+  in_defaults && /^    working-directory:/ {
+    in_defaults = 0
+    next
+  }
+  in_defaults && /^[^ ]/ {
+    # defaults block ended without expected content, print current line
+    in_defaults = 0
+  }
+  in_defaults {
+    next
+  }
+
+  # Strip template prefix from cache-dependency-path
+  /cache-dependency-path:/ {
+    gsub(template "/", "")
+    print
+    next
+  }
+
+  # Remove golangci-lint-action working-directory
+  /^          working-directory:/ {
+    # Check if previous context is golangci-lint (we just remove all step-level working-directory under "with:")
+    next
+  }
+
+  # Remove workingDirectory for wrangler-action
+  /^          workingDirectory:/ {
+    next
+  }
+
+  # Strip template prefix from target/ path in cargo cache
+  /            '"$template"'\/target\// {
+    gsub(template "/", "")
+    print
+    next
+  }
+
+  # Strip template prefix from hashFiles paths
+  /hashFiles\(/ {
+    gsub("'"'"'" template "/", "'"'"'")
+    print
+    next
+  }
+
+  # Replace template name with project name in command strings
+  /--project-name=/ {
+    gsub(template, name)
+    print
+    next
+  }
+
+  # Replace working-directory at step level (for coverage jobs etc.)
+  /^        working-directory:/ {
+    gsub(template, ".")
+    # Only keep if the value is not just "."
+    if ($0 ~ /working-directory: \.$/) {
+      next
+    }
+    print
+    next
+  }
+
+  { print }
+  ' "$src" > "$dest_file"
+}

--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Common utilities for scaffold script
+
+set -euo pipefail
+
+# Valid template names
+VALID_TEMPLATES=(
+  go-rest-api
+  go-graphql-api
+  go-grpc-api
+  go-ssr-web
+  go-cli
+  react-spa
+  react-spa-graphql
+  react-spa-cloudflare
+  python-cli
+  rust-cli
+)
+
+# Artifacts to remove after copy
+ARTIFACTS=(
+  node_modules
+  .venv
+  target
+  server
+  dist
+  .vite
+  bin
+  __pycache__
+  .pytest_cache
+  .mypy_cache
+  .ruff_cache
+  coverage
+  .coverage
+)
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+  echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+warn() {
+  echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+error() {
+  echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+die() {
+  error "$@"
+  exit 1
+}
+
+# Detect template family: go, react, python, rust
+detect_family() {
+  local template="$1"
+  case "$template" in
+    go-*) echo "go" ;;
+    react-*) echo "react" ;;
+    python-*) echo "python" ;;
+    rust-*) echo "rust" ;;
+    *) die "Unknown template family for: $template" ;;
+  esac
+}
+
+# Validate template name
+validate_template() {
+  local template="$1"
+  for t in "${VALID_TEMPLATES[@]}"; do
+    if [[ "$t" == "$template" ]]; then
+      return 0
+    fi
+  done
+  error "Invalid template: $template"
+  echo "Available templates:"
+  for t in "${VALID_TEMPLATES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+}
+
+# Validate destination directory
+validate_dest() {
+  local dest="$1"
+  if [[ -e "$dest" ]]; then
+    die "Destination already exists: $dest"
+  fi
+  local parent
+  parent="$(dirname "$dest")"
+  if [[ ! -d "$parent" ]]; then
+    die "Parent directory does not exist: $parent"
+  fi
+}
+
+# Validate project name (alphanumeric, hyphens, underscores only)
+validate_name() {
+  local name="$1"
+  if [[ ! "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    die "Invalid project name: $name (only alphanumeric, hyphens, and underscores allowed)"
+  fi
+}
+
+# Validate Go module path format
+validate_module() {
+  local module="$1"
+  if [[ ! "$module" =~ ^[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)+$ ]]; then
+    die "Invalid module path: $module (expected format: github.com/<user>/<repo>)"
+  fi
+}
+
+# Copy template and remove build artifacts
+copy_template() {
+  local src="$1"
+  local dest="$2"
+
+  cp -R "$src" "$dest"
+
+  for artifact in "${ARTIFACTS[@]}"; do
+    find "$dest" -maxdepth 2 -name "$artifact" -exec rm -rf {} + 2>/dev/null || true
+  done
+
+  # Remove .git if copied
+  rm -rf "$dest/.git"
+
+  # Remove monorepo-specific documentation
+  rm -f "$dest/docs/SYNC_FILES.md"
+  # Remove empty docs dir if nothing left
+  rmdir "$dest/docs" 2>/dev/null || true
+}

--- a/scripts/scaffold/lib/go.sh
+++ b/scripts/scaffold/lib/go.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Go template replacements
+
+apply_go_replacements() {
+  local dest="$1"
+  local template="$2"
+  local name="$3"
+  local module="$4"
+
+  # Get old module path from go.mod first line
+  local old_module
+  old_module="$(head -1 "$dest/go.mod" | awk '{print $2}')"
+
+  info "Replacing Go module: $old_module -> $module"
+
+  # Replace module path in go.mod
+  sed -i "s|^module ${old_module}$|module ${module}|" "$dest/go.mod"
+
+  # Replace import paths in all .go files
+  find "$dest" -name '*.go' -exec sed -i "s|\"${old_module}/|\"${module}/|g" {} +
+
+  # Handle gqlgen.yml autobind (go-graphql-api)
+  if [[ -f "$dest/gqlgen.yml" ]]; then
+    sed -i "s|\"${old_module}/|\"${module}/|g" "$dest/gqlgen.yml"
+  fi
+
+  # Handle .golangci.yml local-prefixes
+  if [[ -f "$dest/.golangci.yml" ]]; then
+    sed -i "s|${old_module}|${module}|g" "$dest/.golangci.yml"
+  fi
+
+  # For CLI templates: replace binary name references (Cobra Use field, version strings, Makefile BINARY_NAME)
+  if [[ "$template" == "go-cli" ]]; then
+    local bin_name
+    bin_name="$(basename "$module")"
+    # Replace mycli as CLI name in .go files (Cobra Use, version strings, descriptions)
+    find "$dest" -name '*.go' -exec sed -i "s|mycli|${bin_name}|g" {} +
+    # Replace BINARY_NAME in Makefile
+    sed -i "s|^BINARY_NAME := mycli|BINARY_NAME := ${bin_name}|" "$dest/Makefile"
+  fi
+}

--- a/scripts/scaffold/lib/python.sh
+++ b/scripts/scaffold/lib/python.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Python template replacements
+
+apply_python_replacements() {
+  local dest="$1"
+  local template="$2"
+  local name="$3"
+
+  # Convert project name to valid Python package name (hyphens -> underscores)
+  local pkg_name="${name//-/_}"
+
+  info "Python package name: $pkg_name"
+
+  # Replace pyproject.toml fields
+  if [[ -f "$dest/pyproject.toml" ]]; then
+    # Replace project name
+    sed -i "s|^name = \"mycli\"|name = \"${name}\"|" "$dest/pyproject.toml"
+
+    # Replace scripts entry
+    sed -i "s|^mycli = \"mycli\.|${pkg_name} = \"${pkg_name}.|" "$dest/pyproject.toml"
+
+    # Replace hatch build packages
+    sed -i "s|\"src/mycli\"|\"src/${pkg_name}\"|" "$dest/pyproject.toml"
+
+    # Replace coverage source
+    sed -i "s|\"src/mycli\"|\"src/${pkg_name}\"|" "$dest/pyproject.toml"
+
+    info "Updated pyproject.toml"
+  fi
+
+  # Rename src/mycli/ directory
+  if [[ -d "$dest/src/mycli" ]]; then
+    mv "$dest/src/mycli" "$dest/src/${pkg_name}"
+    info "Renamed src/mycli -> src/${pkg_name}"
+  fi
+
+  # Replace import references in .py files
+  find "$dest" -name '*.py' -exec sed -i "s|from mycli|from ${pkg_name}|g; s|import mycli|import ${pkg_name}|g" {} +
+
+  # Replace references in Makefile
+  if [[ -f "$dest/Makefile" ]]; then
+    sed -i "s|mycli|${pkg_name}|g" "$dest/Makefile"
+    info "Updated Makefile references"
+  fi
+
+  # Replace pytest coverage source in CI workflow references
+  find "$dest" -name '*.yml' -exec sed -i "s|--cov=src/mycli|--cov=src/${pkg_name}|g" {} + 2>/dev/null || true
+}

--- a/scripts/scaffold/lib/react.sh
+++ b/scripts/scaffold/lib/react.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# React template replacements
+
+apply_react_replacements() {
+  local dest="$1"
+  local template="$2"
+  local name="$3"
+
+  # Replace package.json name field
+  if [[ -f "$dest/package.json" ]]; then
+    sed -i "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package.json"
+    info "Updated package.json name"
+  fi
+
+  # Replace package-lock.json name field (will be regenerated on npm install, but keep consistent)
+  if [[ -f "$dest/package-lock.json" ]]; then
+    sed -i "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package-lock.json"
+  fi
+
+  # Replace wrangler.toml name (react-spa-cloudflare)
+  if [[ -f "$dest/wrangler.toml" ]]; then
+    sed -i "s|^name = \"${template}\"|name = \"${name}\"|" "$dest/wrangler.toml"
+    info "Updated wrangler.toml name"
+  fi
+}

--- a/scripts/scaffold/lib/rust.sh
+++ b/scripts/scaffold/lib/rust.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Rust template replacements
+
+apply_rust_replacements() {
+  local dest="$1"
+  local template="$2"
+  local name="$3"
+
+  # Convert project name for Rust crate (hyphens -> underscores for lib name)
+  local crate_name="${name//-/_}"
+
+  # Replace Cargo.toml package name
+  if [[ -f "$dest/Cargo.toml" ]]; then
+    sed -i "s|^name = \"rust-cli\"|name = \"${name}\"|" "$dest/Cargo.toml"
+    # Replace bin name
+    sed -i "s|^name = \"mycli\"|name = \"${name}\"|" "$dest/Cargo.toml"
+    info "Updated Cargo.toml"
+  fi
+
+  # Replace command name in src/cli.rs
+  if [[ -f "$dest/src/cli.rs" ]]; then
+    sed -i "s|command(name = \"mycli\")|command(name = \"${name}\")|" "$dest/src/cli.rs"
+    # Replace crate import (rust_cli -> new crate name)
+    sed -i "s|use rust_cli::|use ${crate_name}::|g" "$dest/src/cli.rs"
+    info "Updated src/cli.rs"
+  fi
+
+  # Replace BINARY_NAME in Makefile
+  if [[ -f "$dest/Makefile" ]]; then
+    sed -i "s|^BINARY_NAME := mycli|BINARY_NAME := ${name}|" "$dest/Makefile"
+    info "Updated Makefile BINARY_NAME"
+  fi
+}

--- a/scripts/scaffold/lib/rust.sh
+++ b/scripts/scaffold/lib/rust.sh
@@ -30,4 +30,7 @@ apply_rust_replacements() {
     sed -i "s|^BINARY_NAME := mycli|BINARY_NAME := ${name}|" "$dest/Makefile"
     info "Updated Makefile BINARY_NAME"
   fi
+
+  # Replace binary name in test files (assert_cmd's cargo_bin("mycli"))
+  find "$dest/tests" -name '*.rs' -exec sed -i "s|\"mycli\"|\"${name}\"|g" {} + 2>/dev/null || true
 }

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Scaffold a standalone project from a monorepo template
+#
+# Usage:
+#   bash scripts/scaffold/scaffold.sh template=<name> dest=<path> name=<project-name> [module=<go-module>]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+# --- Argument parsing ---
+template=""
+dest=""
+name=""
+module=""
+
+for arg in "$@"; do
+  case "$arg" in
+    template=*) template="${arg#template=}" ;;
+    dest=*) dest="${arg#dest=}" ;;
+    name=*) name="${arg#name=}" ;;
+    module=*) module="${arg#module=}" ;;
+    *) die "Unknown argument: $arg" ;;
+  esac
+done
+
+# --- Validation ---
+[[ -z "$template" ]] && die "Missing required argument: template="
+[[ -z "$dest" ]] && die "Missing required argument: dest="
+[[ -z "$name" ]] && die "Missing required argument: name="
+
+validate_template "$template"
+validate_name "$name"
+validate_dest "$dest"
+
+family="$(detect_family "$template")"
+
+# Go templates require module=
+if [[ "$family" == "go" ]]; then
+  [[ -z "$module" ]] && die "Go templates require module= argument (e.g., module=github.com/user/repo)"
+  validate_module "$module"
+fi
+
+# Non-Go templates: warn if module is provided
+if [[ "$family" != "go" && -n "$module" ]]; then
+  warn "module= is ignored for $family templates"
+  module=""
+fi
+
+# --- Copy template ---
+info "Copying template '$template' to '$dest'..."
+copy_template "$REPO_ROOT/$template" "$dest"
+
+# --- CI workflow transformation (before family replacements so they can process CI files too) ---
+info "Transforming CI workflows..."
+source "$SCRIPT_DIR/lib/ci.sh"
+transform_ci_workflows "$dest" "$REPO_ROOT" "$template" "$name"
+
+# --- Generic template name replacement (before family-specific to avoid double-replacement) ---
+# Replace template name with project name in Makefiles, HTML, graphql comments, etc.
+generic_files="$(grep -rl "${template}" "$dest" --include='*.html' --include='Makefile' --include='*.graphql' 2>/dev/null || true)"
+if [[ -n "$generic_files" ]]; then
+  while IFS= read -r f; do
+    sed -i "s|${template}|${name}|g" "$f"
+  done <<< "$generic_files"
+fi
+
+# --- Family-specific replacements ---
+info "Applying $family replacements..."
+
+case "$family" in
+  go)
+    source "$SCRIPT_DIR/lib/go.sh"
+    apply_go_replacements "$dest" "$template" "$name" "$module"
+    ;;
+  react)
+    source "$SCRIPT_DIR/lib/react.sh"
+    apply_react_replacements "$dest" "$template" "$name"
+    ;;
+  python)
+    source "$SCRIPT_DIR/lib/python.sh"
+    apply_python_replacements "$dest" "$template" "$name"
+    ;;
+  rust)
+    source "$SCRIPT_DIR/lib/rust.sh"
+    apply_rust_replacements "$dest" "$template" "$name"
+    ;;
+esac
+
+# --- README replacement ---
+info "Generating README..."
+readme_template="$SCRIPT_DIR/templates/README.md.tmpl"
+if [[ -f "$readme_template" ]]; then
+  sed \
+    -e "s|{{NAME}}|$name|g" \
+    -e "s|{{TEMPLATE}}|$template|g" \
+    -e "s|{{FAMILY}}|$family|g" \
+    "$readme_template" > "$dest/README.md"
+fi
+
+# --- Completion message ---
+echo ""
+info "Project '$name' scaffolded successfully at: $dest"
+echo ""
+echo "Next steps:"
+
+case "$family" in
+  go)
+    echo "  cd $dest"
+    echo "  go mod tidy"
+    echo "  make ci"
+    ;;
+  react)
+    echo "  cd $dest"
+    echo "  npm install"
+    echo "  make ci"
+    if [[ "$template" == "react-spa-cloudflare" ]]; then
+      echo ""
+      echo "Required secrets for deployment:"
+      echo "  - CLOUDFLARE_API_TOKEN"
+      echo "  - CLOUDFLARE_ACCOUNT_ID"
+    fi
+    ;;
+  python)
+    echo "  cd $dest"
+    echo "  uv sync --all-extras"
+    echo "  make ci"
+    ;;
+  rust)
+    echo "  cd $dest"
+    echo "  cargo build"
+    echo "  make ci"
+    ;;
+esac
+
+echo ""
+echo "CI workflow generated at: $dest/.github/workflows/ci.yml"

--- a/scripts/scaffold/templates/README.md.tmpl
+++ b/scripts/scaffold/templates/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{NAME}}
+
+Scaffolded from [my-boilerplate/{{TEMPLATE}}](https://github.com/rengotaku/my-boilerplate/tree/main/{{TEMPLATE}}).
+
+## Getting Started
+
+See the Makefile for available commands:
+
+```bash
+make help
+```
+
+## CI
+
+CI workflow is at `.github/workflows/ci.yml`.
+
+```bash
+make ci
+```


### PR DESCRIPTION
## 概要
- モノレポ内の10テンプレートから単体動作可能なプロジェクトを生成する `make scaffold` コマンドを追加
- Go（5種）、React（3種）、Python（1種）、Rust（1種）の系統別置換に対応
  - Go: module path、import path、.golangci.yml local-prefixes、go-cli の mycli バイナリ名
  - React: package.json name、wrangler.toml name、package-lock.json
  - Python: pyproject.toml、src/mycli ディレクトリリネーム、import 置換
  - Rust: Cargo.toml、cli.rs command name、Makefile BINARY_NAME、テストの cargo_bin
- CI workflow 変換: paths フィルタ、defaults working-directory、cache-dependency-path プレフィックス、golangci-lint working-directory を除去
- デプロイ workflow（cloudflare）も同様に変換
- 入力バリデーション: テンプレート名許可リスト、name フォーマット制約、Go module path 形式チェック

## 使い方
```bash
# Go
make scaffold template=go-rest-api dest=/tmp/myapp name=myapp module=github.com/user/myapp

# React
make scaffold template=react-spa dest=/tmp/myapp name=myapp

# Python
make scaffold template=python-cli dest=/tmp/mycli name=mycli

# Rust
make scaffold template=rust-cli dest=/tmp/mycli name=mycli
```

## テスト計画
- [x] 全10テンプレートの scaffold 成功を確認
- [x] Go: module path、import path、.golangci.yml、go-cli の mycli 置換
- [x] React: package.json、wrangler.toml、Makefile status 行
- [x] Python: pyproject.toml、src/mycli リネーム、Makefile・CI の mycli 参照
- [x] Rust: Cargo.toml、cli.rs、Makefile BINARY_NAME、テストの cargo_bin
- [x] CI workflow: paths/defaults/cache-dependency-path/working-directory 除去
- [x] デプロイ workflow（cloudflare）の変換
- [x] エラーケース: 無効テンプレート、Go の module 未指定、dest 既存、不正な name 形式
- [ ] CI: scaffold-verify.yml マトリクスで全10テンプレートの自動検証

Closes #75