### PR TITLE
fix: scaffold から .claude ディレクトリを除外

### DIFF
--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -125,8 +125,9 @@ copy_template() {
     find "$dest" -maxdepth 2 -name "$artifact" -exec rm -rf {} + 2>/dev/null || true
   done
 
-  # Remove .git if copied
+  # Remove .git and .claude if copied (symlinks to monorepo parent)
   rm -rf "$dest/.git"
+  rm -rf "$dest/.claude"
 
   # Remove monorepo-specific documentation
   rm -f "$dest/docs/SYNC_FILES.md"


### PR DESCRIPTION
## 概要
- scaffold 時にテンプレートの `.claude` シンボリックリンク（`../.claude` への参照）がコピーされてしまう問題を修正
- `copy_template` で `.git` と同様に `.claude` も削除するよう追加

## 背景
PR #76 のマージ後に発覚。`003-scaffold-cmd` ブランチに修正を push したが、マージに含まれていなかったため cherry-pick で反映。

## テスト計画
- [x] scaffold 後に `.claude` が含まれないことをローカルで確認済み