### PR TITLE
refactor: Go CI を Reusable Workflow で共通化

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,57 @@
+name: Go CI (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+        description: "Project directory (e.g., go-rest-api)"
+      go-versions:
+        required: true
+        type: string
+        description: 'JSON array of Go versions (e.g., ''["1.24", "1.25"]'')'
+      test-paths:
+        required: false
+        type: string
+        default: "./internal/..."
+        description: "Go test paths (e.g., ./internal/...)"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ${{ fromJSON(inputs.go-versions) }}
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Test with coverage
+        run: |
+          go test ${{ inputs.test-paths }} -coverprofile=coverage.out
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Coverage: $COVERAGE%"
+          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+            echo "Coverage $COVERAGE% is below 80%"
+            exit 1
+          fi

--- a/.github/workflows/go-cli.yml
+++ b/.github/workflows/go-cli.yml
@@ -6,46 +6,17 @@ on:
     paths:
       - 'go-cli/**'
       - '.github/workflows/go-cli.yml'
+      - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
       - 'go-cli/**'
       - '.github/workflows/go-cli.yml'
-
-defaults:
-  run:
-    working-directory: go-cli
+      - '.github/workflows/go-ci.yml'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.21", "1.22"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: go-cli/go.sum
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11
-          working-directory: go-cli
-
-      - name: Test with coverage
-        run: |
-          go test ./internal/... -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage $COVERAGE% is below 80%"
-            exit 1
-          fi
+  ci:
+    uses: ./.github/workflows/go-ci.yml
+    with:
+      working-directory: go-cli
+      go-versions: '["1.21", "1.22"]'
+      test-paths: "./internal/..."

--- a/.github/workflows/go-graphql-api.yml
+++ b/.github/workflows/go-graphql-api.yml
@@ -6,46 +6,17 @@ on:
     paths:
       - 'go-graphql-api/**'
       - '.github/workflows/go-graphql-api.yml'
+      - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
       - 'go-graphql-api/**'
       - '.github/workflows/go-graphql-api.yml'
-
-defaults:
-  run:
-    working-directory: go-graphql-api
+      - '.github/workflows/go-ci.yml'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.25"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: go-graphql-api/go.sum
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11
-          working-directory: go-graphql-api
-
-      - name: Test with coverage
-        run: |
-          go test ./internal/service/... ./internal/repository/... -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage $COVERAGE% is below 80%"
-            exit 1
-          fi
+  ci:
+    uses: ./.github/workflows/go-ci.yml
+    with:
+      working-directory: go-graphql-api
+      go-versions: '["1.25"]'
+      test-paths: "./internal/service/... ./internal/repository/..."

--- a/.github/workflows/go-grpc-api.yml
+++ b/.github/workflows/go-grpc-api.yml
@@ -6,46 +6,17 @@ on:
     paths:
       - 'go-grpc-api/**'
       - '.github/workflows/go-grpc-api.yml'
+      - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
       - 'go-grpc-api/**'
       - '.github/workflows/go-grpc-api.yml'
-
-defaults:
-  run:
-    working-directory: go-grpc-api
+      - '.github/workflows/go-ci.yml'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.24", "1.25"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: go-grpc-api/go.sum
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11
-          working-directory: go-grpc-api
-
-      - name: Test with coverage
-        run: |
-          go test ./internal/... -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage $COVERAGE% is below 80%"
-            exit 1
-          fi
+  ci:
+    uses: ./.github/workflows/go-ci.yml
+    with:
+      working-directory: go-grpc-api
+      go-versions: '["1.24", "1.25"]'
+      test-paths: "./internal/..."

--- a/.github/workflows/go-rest-api.yml
+++ b/.github/workflows/go-rest-api.yml
@@ -6,46 +6,17 @@ on:
     paths:
       - 'go-rest-api/**'
       - '.github/workflows/go-rest-api.yml'
+      - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
       - 'go-rest-api/**'
       - '.github/workflows/go-rest-api.yml'
-
-defaults:
-  run:
-    working-directory: go-rest-api
+      - '.github/workflows/go-ci.yml'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.22", "1.23"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: go-rest-api/go.sum
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11
-          working-directory: go-rest-api
-
-      - name: Test with coverage
-        run: |
-          go test ./internal/... -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage $COVERAGE% is below 80%"
-            exit 1
-          fi
+  ci:
+    uses: ./.github/workflows/go-ci.yml
+    with:
+      working-directory: go-rest-api
+      go-versions: '["1.22", "1.23"]'
+      test-paths: "./internal/..."

--- a/.github/workflows/go-ssr-web.yml
+++ b/.github/workflows/go-ssr-web.yml
@@ -6,46 +6,17 @@ on:
     paths:
       - 'go-ssr-web/**'
       - '.github/workflows/go-ssr-web.yml'
+      - '.github/workflows/go-ci.yml'
   pull_request:
     paths:
       - 'go-ssr-web/**'
       - '.github/workflows/go-ssr-web.yml'
-
-defaults:
-  run:
-    working-directory: go-ssr-web
+      - '.github/workflows/go-ci.yml'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ["1.22", "1.23"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: go-ssr-web/go.sum
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.11
-          working-directory: go-ssr-web
-
-      - name: Test with coverage
-        run: |
-          go test ./internal/... -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-          echo "Coverage: $COVERAGE%"
-          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
-            echo "Coverage $COVERAGE% is below 80%"
-            exit 1
-          fi
+  ci:
+    uses: ./.github/workflows/go-ci.yml
+    with:
+      working-directory: go-ssr-web
+      go-versions: '["1.22", "1.23"]'
+      test-paths: "./internal/..."

--- a/scripts/scaffold/lib/ci.sh
+++ b/scripts/scaffold/lib/ci.sh
@@ -12,7 +12,12 @@ transform_ci_workflows() {
   # Transform CI workflow
   local ci_src="$repo_root/.github/workflows/${template}.yml"
   if [[ -f "$ci_src" ]]; then
-    transform_workflow "$ci_src" "$dest/.github/workflows/ci.yml" "$template" "$name"
+    # Check if this is a reusable workflow caller (contains "uses: ./.github/workflows/")
+    if grep -q 'uses: \./.github/workflows/go-ci\.yml' "$ci_src" 2>/dev/null; then
+      expand_go_reusable_workflow "$ci_src" "$repo_root" "$dest/.github/workflows/ci.yml" "$template" "$name"
+    else
+      transform_workflow "$ci_src" "$dest/.github/workflows/ci.yml" "$template" "$name"
+    fi
     info "Created CI workflow: .github/workflows/ci.yml"
   else
     warn "No CI workflow found: $ci_src"
@@ -24,6 +29,100 @@ transform_ci_workflows() {
     transform_workflow "$deploy_src" "$dest/.github/workflows/deploy.yml" "$template" "$name"
     info "Created deploy workflow: .github/workflows/deploy.yml"
   fi
+}
+
+# Expand a Go reusable workflow caller into a standalone CI workflow
+expand_go_reusable_workflow() {
+  local caller_src="$1"
+  local repo_root="$2"
+  local dest_file="$3"
+  local template="$4"
+  local name="$5"
+
+  local reusable_src="$repo_root/.github/workflows/go-ci.yml"
+  if [[ ! -f "$reusable_src" ]]; then
+    warn "Reusable workflow not found: $reusable_src, falling back to direct transform"
+    transform_workflow "$caller_src" "$dest_file" "$template" "$name"
+    return
+  fi
+
+  # Extract inputs from caller workflow
+  local go_versions test_paths
+  go_versions="$(grep "go-versions:" "$caller_src" | sed "s/.*go-versions: *'//" | sed "s/'$//")"
+  test_paths="$(grep "test-paths:" "$caller_src" | sed 's/.*test-paths: *"//' | sed 's/"$//')"
+  [[ -z "$test_paths" ]] && test_paths="./internal/..."
+
+  # Generate standalone workflow from reusable template
+  # Replace workflow_call inputs with extracted values and strip monorepo config
+  awk -v name="$name" -v go_versions="$go_versions" -v test_paths="$test_paths" '
+  BEGIN {
+    in_workflow_call = 0
+    in_inputs = 0
+    skip_input = 0
+  }
+
+  # Replace workflow name
+  /^name:/ {
+    print "name: " name " CI"
+    next
+  }
+
+  # Replace workflow_call trigger with push/pull_request
+  /^on:/ {
+    print "on:"
+    print "  push:"
+    print "    branches: [main]"
+    print "  pull_request:"
+    in_workflow_call = 1
+    next
+  }
+  in_workflow_call && /^[^ ]/ && !/^on:/ {
+    in_workflow_call = 0
+  }
+  in_workflow_call {
+    next
+  }
+
+  # Replace input references with actual values
+  {
+    gsub(/\$\{\{ fromJSON\(inputs\.go-versions\) \}\}/, go_versions)
+    gsub(/\$\{\{ inputs\.working-directory \}\}/, ".")
+    gsub(/\$\{\{ inputs\.test-paths \}\}/, test_paths)
+  }
+
+  # Remove defaults block (working-directory: ".")
+  /^    defaults:/ {
+    in_defaults = 1
+    next
+  }
+  in_defaults && /^      run:/ { next }
+  in_defaults && /^        working-directory:/ {
+    in_defaults = 0
+    next
+  }
+  in_defaults && /^    [^ ]/ {
+    in_defaults = 0
+  }
+  in_defaults { next }
+
+  # Strip "." prefix from cache-dependency-path
+  /cache-dependency-path:/ {
+    gsub(/\.\// , "")
+    gsub(": \./", ": ")
+    print
+    next
+  }
+
+  # Remove golangci-lint working-directory when value is "."
+  /working-directory:/ && /: \.$/ {
+    next
+  }
+  /working-directory:/ && /: "\."$/ {
+    next
+  }
+
+  { print }
+  ' "$reusable_src" > "$dest_file"
 }
 
 transform_workflow() {
@@ -60,7 +159,6 @@ transform_workflow() {
   # Remove defaults: run: working-directory: block (3-line block)
   /^defaults:/ {
     in_defaults = 1
-    defaults_depth = 0
     next
   }
   in_defaults && /^  run:/ {
@@ -87,7 +185,6 @@ transform_workflow() {
 
   # Remove golangci-lint-action working-directory
   /^          working-directory:/ {
-    # Check if previous context is golangci-lint (we just remove all step-level working-directory under "with:")
     next
   }
 


### PR DESCRIPTION
## 概要
- 5つの Go プロジェクト CI ワークフローの重複ロジックを go-ci.yml Reusable Workflow に集約
- 各プロジェクトは薄い caller workflow（約20行）から共通ワークフローを呼び出す形式に変換
- Dependabot のアクションバージョンアップ時に go-ci.yml 1ファイルの変更で済む

## 変更内容

### 新規
- .github/workflows/go-ci.yml — Reusable Workflow（workflow_call）
  - inputs: working-directory, go-versions（JSON配列）, test-paths

### 変更
- go-rest-api.yml, go-graphql-api.yml, go-grpc-api.yml, go-ssr-web.yml, go-cli.yml — caller workflow に簡素化
- scripts/scaffold/lib/ci.sh — Reusable Workflow caller を検出したら展開してスタンドアロン CI を生成

## scaffold との整合性
scaffold 時は caller workflow を検出し、go-ci.yml の内容を inputs の値で展開してスタンドアロン CI を生成します。scaffold された単体リポジトリは Reusable Workflow に依存しません。

## テスト計画
- [x] scaffold で go-rest-api → スタンドアロン CI が正しく生成されることを確認
- [x] scaffold で go-graphql-api → test-paths が正しく展開されることを確認
- [ ] CI: 全5つの Go ワークフローが Reusable Workflow 経由で pass すること
- [ ] CI: scaffold-verify で全 Go テンプレートが pass すること

Closes #73