### PR TITLE
fix: project-name をハードコードから変数化 (#79)

### DIFF
--- a/.github/workflows/react-spa-cloudflare-deploy.yml
+++ b/.github/workflows/react-spa-cloudflare-deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy react-spa-cloudflare to Cloudflare Pages
 
+env:
+  PROJECT_NAME: react-spa-cloudflare
+
 on:
   push:
     branches: [main]
@@ -40,5 +43,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=react-spa-cloudflare
+          command: pages deploy dist --project-name=${{ env.PROJECT_NAME }}
           workingDirectory: react-spa-cloudflare

--- a/react-spa-cloudflare/Makefile
+++ b/react-spa-cloudflare/Makefile
@@ -2,6 +2,7 @@
 
 # Variables
 PORT ?= 5173
+PROJECT_NAME := react-spa-cloudflare
 
 dev:
 	npm run dev
@@ -50,13 +51,13 @@ pages-login:
 	npx wrangler login
 
 pages-create:
-	npx wrangler pages project create react-spa-cloudflare --production-branch=main
+	npx wrangler pages project create $(PROJECT_NAME) --production-branch=main
 
 # Cloudflare Pages deployment
 deploy:
 	npm run build
-	npx wrangler pages deploy dist --project-name=react-spa-cloudflare
+	npx wrangler pages deploy dist --project-name=$(PROJECT_NAME)
 
 deploy-preview:
 	npm run build
-	npx wrangler pages deploy dist --project-name=react-spa-cloudflare --branch=preview
+	npx wrangler pages deploy dist --project-name=$(PROJECT_NAME) --branch=preview

--- a/scripts/scaffold/lib/ci.sh
+++ b/scripts/scaffold/lib/ci.sh
@@ -110,8 +110,8 @@ transform_workflow() {
     next
   }
 
-  # Replace template name with project name in command strings
-  /--project-name=/ {
+  # Replace template name with project name in command strings and env variables
+  /--project-name=/ || /PROJECT_NAME:/ {
     gsub(template, name)
     print
     next


### PR DESCRIPTION
## 概要

`react-spa-cloudflare-deploy.yml` と `Makefile` でハードコードされていた `project-name` を変数化。

## 変更内容

- **`.github/workflows/react-spa-cloudflare-deploy.yml`**: `env.PROJECT_NAME` を定義し、wrangler コマンドで `${{ env.PROJECT_NAME }}` を参照
- **`react-spa-cloudflare/Makefile`**: `PROJECT_NAME` 変数を定義し、`pages-create`, `deploy`, `deploy-preview` で `$(PROJECT_NAME)` を参照
- **`scripts/scaffold/lib/ci.sh`**: scaffold 時に `PROJECT_NAME:` 行のテンプレート名も置換するよう対応

## テスト計画

- [ ] deploy ワークフローが正常に動作すること
- [ ] scaffold で生成したプロジェクトの deploy.yml に正しいプロジェクト名が設定されること

Closes #79