### PR TITLE
feat(scripts): リポジトリ未取得でもテンプレート展開できる download.sh を追加

### DIFF
--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -62,7 +62,7 @@ jobs:
             template=${{ matrix.template }} \
             dest=/tmp/test-${{ matrix.template }} \
             name=test-${{ matrix.template }} \
-            module=github.com/test/test-${{ matrix.template }}
+            go-module-name=github.com/test/test-${{ matrix.template }}
 
       - name: Verify scaffolded project
         working-directory: /tmp/test-${{ matrix.template }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,14 +38,11 @@ TypeScript 5.9, React 19: Follow standard conventions
 ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへ scaffold する（`download.sh` は scaffold を必ず実行する。opt-out は無い）。
 
 ```bash
-# 共通（name / go-module-name は basename(<dest>) から自動推定）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- <template> <dest>
-
-# 公開予定の go-* プロジェクトは module パスを明示
-curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- <template> <dest> --go-module-name=<go-module>
 ```
+
+`name` は `basename(<dest>)` から自動推定。Go テンプレートの `go.mod` も `basename(<dest>)` をローカル限定モジュール名で初期化するため、**公開する場合のみ** scaffold 完了後に `go mod edit -module github.com/<user>/<repo>` で書き換える（完了メッセージにも案内が出る）。
 
 理由: 構造模倣だと `envconfig` / 共通 logger / Makefile ターゲット等の既存資産が引き継がれず、ボイラープレートの恩恵が受けられない（#97 参照）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,13 @@ TypeScript 5.9, React 19: Follow standard conventions
 ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへ scaffold する（`download.sh` は scaffold を必ず実行する。opt-out は無い）。
 
 ```bash
-# go-* テンプレート（--go-module-name 必須）
-curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- <template> <dest> --go-module-name=<go-module>
-
-# それ以外（react / python / rust）。--name 省略時は basename(<dest>) が採用される
+# 共通（name / go-module-name は basename(<dest>) から自動推定）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- <template> <dest>
+
+# 公開予定の go-* プロジェクトは module パスを明示
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- <template> <dest> --go-module-name=<go-module>
 ```
 
 理由: 構造模倣だと `envconfig` / 共通 logger / Makefile ターゲット等の既存資産が引き継がれず、ボイラープレートの恩恵が受けられない（#97 参照）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ TypeScript 5.9, React 19: Follow standard conventions
 ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへ scaffold する（`download.sh` は scaffold を必ず実行する。opt-out は無い）。
 
 ```bash
-# go-* テンプレート（--module 必須）
+# go-* テンプレート（--go-module-name 必須）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- <template> <dest> --module=<go-module>
+  | sh -s -- <template> <dest> --go-module-name=<go-module>
 
 # それ以外（react / python / rust）。--name 省略時は basename(<dest>) が採用される
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,16 @@ TypeScript 5.9, React 19: Follow standard conventions
 
 ## テンプレートの利用方法
 
-ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへコピーしてから着手する。
+ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへ scaffold する（`download.sh` は scaffold を必ず実行する。opt-out は無い）。
 
 ```bash
-# プロジェクト名・モジュールパスを置換した状態でコピー
+# go-* テンプレート（--module 必須）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- <template> <dest> --name=<dest-basename> [--module=<go-module>]
+  | sh -s -- <template> <dest> --module=<go-module>
+
+# それ以外（react / python / rust）。--name 省略時は basename(<dest>) が採用される
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- <template> <dest>
 ```
 
 理由: 構造模倣だと `envconfig` / 共通 logger / Makefile ターゲット等の既存資産が引き継がれず、ボイラープレートの恩恵が受けられない（#97 参照）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,4 +32,17 @@ TypeScript 5.9, React 19: Follow standard conventions
 - 001-graphql-spa: Added TypeScript 5.9, React 19 + Apollo Client 3.x, @graphql-codegen/*, MUI 7, Zustand, React Hook Form, Zod
 
 <!-- MANUAL ADDITIONS START -->
+
+## テンプレートの利用方法
+
+ユーザーから「my-boilerplate の `<template>` を使って」と指示された場合、**構造だけ真似てゼロから書いてはいけない**。必ず `scripts/download.sh` でファイル一式を対象ディレクトリへコピーしてから着手する。
+
+```bash
+# プロジェクト名・モジュールパスを置換した状態でコピー
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- <template> <dest> --name=<dest-basename> [--module=<go-module>]
+```
+
+理由: 構造模倣だと `envconfig` / 共通 logger / Makefile ターゲット等の既存資産が引き継がれず、ボイラープレートの恩恵が受けられない（#97 参照）。
+
 <!-- MANUAL ADDITIONS END -->

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ e2e:
 e2e-update-snapshots:
 	PLAYWRIGHT_IMAGE=$(PLAYWRIGHT_IMAGE) ./scripts/e2e-update-snapshots.sh
 
-## scaffold: Generate standalone project from template (template= dest= name= [module=])
+## scaffold: Generate standalone project from template (template= dest= name= [go-module-name=])
 scaffold:
 	@bash scripts/scaffold/scaffold.sh \
-		template='$(template)' dest='$(dest)' name='$(name)' module='$(module)'
+		template='$(template)' dest='$(dest)' name='$(name)' go-module-name='$(go-module-name)'
 
 ## help: Show this help
 help:

--- a/README.md
+++ b/README.md
@@ -96,12 +96,34 @@ When adding a new server project:
 
 ## Usage
 
+リポジトリをクローンせずに、テンプレート 1 つだけを任意のディレクトリへ取り出せます。
+
 ```bash
-# Clone specific boilerplate
-cp -r python-cli ~/projects/my-new-project
-cd ~/projects/my-new-project
-make install
+# Plain copy（テンプレート名がソースに残る、最短）
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-ssr-web ~/projects/my-new-app
+
+# Scaffolding 付き（プロジェクト名・モジュールパスを置換）
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-ssr-web ~/projects/my-new-app \
+      --name=my-new-app --module=github.com/me/my-new-app
 ```
+
+オプション:
+
+| Option | Description |
+|--------|-------------|
+| `--name=NAME` | プロジェクト名。指定すると placeholder を置換 |
+| `--module=MODULE` | Go モジュールパス。`go-*` テンプレート + scaffold 時は必須 |
+
+環境変数で fork や別 ref を指定可能:
+
+```bash
+MY_BOILERPLATE_REPO=myorg/my-fork MY_BOILERPLATE_REF=v1.0.0 \
+  sh download.sh go-ssr-web ~/projects/my-app
+```
+
+詳細は [`scripts/download.sh --help`](./scripts/download.sh)。リポジトリをクローン済みなら従来通り [`scripts/scaffold/scaffold.sh`](./scripts/scaffold/scaffold.sh) も使えます。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,9 @@ When adding a new server project:
 リポジトリをクローンせずに、テンプレートを 1 コマンドで scaffold 済みのスタンドアロンプロジェクトとして配置できます。**scaffold（placeholder 置換）は常時実行**で opt-out はありません。
 
 ```bash
-# どのテンプレートも基本これだけ。`name` も `go-module-name` も <dest> から自動推定される
+# どのテンプレートも基本これだけ。`name` は <dest> から自動推定される
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- go-ssr-web ~/projects/my-new-app
-
-# 公開予定の Go プロジェクトは module パスを明示的に指定
-curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- go-ssr-web ~/projects/my-new-app \
-      --go-module-name=github.com/me/my-new-app
 ```
 
 オプション:
@@ -114,7 +109,13 @@ curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/script
 | Option | Description |
 |--------|-------------|
 | `--name=NAME` | プロジェクト名。省略時は `basename(<dest>)` |
-| `--go-module-name=MODULE` | `go.mod` の `module` 行に書かれる値。省略時は `basename(<dest>)`（ローカル限定モジュール）。公開する場合は `github.com/<user>/<repo>` のような canonical path を明示 |
+
+Go テンプレートの場合、`go.mod` の `module` 行は `basename(<dest>)`（ローカル限定モジュール）で初期化されます。**公開予定の場合**はスキャフォールド後に canonical path へ書き換えてください:
+
+```bash
+cd ~/projects/my-new-app
+go mod edit -module github.com/<user>/<repo>
+```
 
 環境変数で fork や別 ref を指定可能:
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ When adding a new server project:
 リポジトリをクローンせずに、テンプレートを 1 コマンドで scaffold 済みのスタンドアロンプロジェクトとして配置できます。**scaffold（placeholder 置換）は常時実行**で opt-out はありません。
 
 ```bash
-# React / Python / Rust テンプレート（--module 不要、name は dest の basename を採用）
+# React / Python / Rust テンプレート（--go-module-name 不要、name は dest の basename を採用）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- react-spa ~/projects/my-new-app
 
-# Go テンプレート（--module 必須）
+# Go テンプレート（--go-module-name 必須）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- go-ssr-web ~/projects/my-new-app \
-      --module=github.com/me/my-new-app
+      --go-module-name=github.com/me/my-new-app
 ```
 
 オプション:
@@ -114,7 +114,7 @@ curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/script
 | Option | Description |
 |--------|-------------|
 | `--name=NAME` | プロジェクト名。省略時は `basename(<dest>)` |
-| `--module=MODULE` | Go モジュールパス。`go-*` テンプレート時は必須 |
+| `--go-module-name=MODULE` | `go.mod` の `module` 行に書かれるパス。`go-*` テンプレート時は必須 |
 
 環境変数で fork や別 ref を指定可能:
 

--- a/README.md
+++ b/README.md
@@ -96,34 +96,34 @@ When adding a new server project:
 
 ## Usage
 
-リポジトリをクローンせずに、テンプレート 1 つだけを任意のディレクトリへ取り出せます。
+リポジトリをクローンせずに、テンプレートを 1 コマンドで scaffold 済みのスタンドアロンプロジェクトとして配置できます。**scaffold（placeholder 置換）は常時実行**で opt-out はありません。
 
 ```bash
-# Plain copy（テンプレート名がソースに残る、最短）
+# React / Python / Rust テンプレート（--module 不要、name は dest の basename を採用）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- go-ssr-web ~/projects/my-new-app
+  | sh -s -- react-spa ~/projects/my-new-app
 
-# Scaffolding 付き（プロジェクト名・モジュールパスを置換）
+# Go テンプレート（--module 必須）
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- go-ssr-web ~/projects/my-new-app \
-      --name=my-new-app --module=github.com/me/my-new-app
+      --module=github.com/me/my-new-app
 ```
 
 オプション:
 
 | Option | Description |
 |--------|-------------|
-| `--name=NAME` | プロジェクト名。指定すると placeholder を置換 |
-| `--module=MODULE` | Go モジュールパス。`go-*` テンプレート + scaffold 時は必須 |
+| `--name=NAME` | プロジェクト名。省略時は `basename(<dest>)` |
+| `--module=MODULE` | Go モジュールパス。`go-*` テンプレート時は必須 |
 
 環境変数で fork や別 ref を指定可能:
 
 ```bash
 MY_BOILERPLATE_REPO=myorg/my-fork MY_BOILERPLATE_REF=v1.0.0 \
-  sh download.sh go-ssr-web ~/projects/my-app
+  sh download.sh react-spa ~/projects/my-app
 ```
 
-詳細は [`scripts/download.sh --help`](./scripts/download.sh)。リポジトリをクローン済みなら従来通り [`scripts/scaffold/scaffold.sh`](./scripts/scaffold/scaffold.sh) も使えます。
+リポジトリをクローン済みなら直接 [`scripts/scaffold/scaffold.sh`](./scripts/scaffold/scaffold.sh) も使えます。`download.sh` はそれをラップして「リポジトリ未取得」状態から実行できるようにしたものです。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ When adding a new server project:
 リポジトリをクローンせずに、テンプレートを 1 コマンドで scaffold 済みのスタンドアロンプロジェクトとして配置できます。**scaffold（placeholder 置換）は常時実行**で opt-out はありません。
 
 ```bash
-# React / Python / Rust テンプレート（--go-module-name 不要、name は dest の basename を採用）
+# どのテンプレートも基本これだけ。`name` も `go-module-name` も <dest> から自動推定される
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-  | sh -s -- react-spa ~/projects/my-new-app
+  | sh -s -- go-ssr-web ~/projects/my-new-app
 
-# Go テンプレート（--go-module-name 必須）
+# 公開予定の Go プロジェクトは module パスを明示的に指定
 curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
   | sh -s -- go-ssr-web ~/projects/my-new-app \
       --go-module-name=github.com/me/my-new-app
@@ -114,7 +114,7 @@ curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/script
 | Option | Description |
 |--------|-------------|
 | `--name=NAME` | プロジェクト名。省略時は `basename(<dest>)` |
-| `--go-module-name=MODULE` | `go.mod` の `module` 行に書かれるパス。`go-*` テンプレート時は必須 |
+| `--go-module-name=MODULE` | `go.mod` の `module` 行に書かれる値。省略時は `basename(<dest>)`（ローカル限定モジュール）。公開する場合は `github.com/<user>/<repo>` のような canonical path を明示 |
 
 環境変数で fork や別 ref を指定可能:
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -24,20 +24,22 @@
 # Optional:
 #   --name=NAME              Project name written into Makefile /
 #                            package.json / etc. Defaults to basename(<dest>).
-#
-# Required for go-* templates:
-#   --go-module-name=MODULE  The value written into go.mod's `module` line
-#                            (e.g., github.com/user/repo).
+#   --go-module-name=MODULE  Value written into go.mod's `module` line for
+#                            go-* templates. Defaults to basename(<dest>),
+#                            which produces a local-only module suitable for
+#                            prototyping. Pass an explicit canonical path
+#                            (e.g., github.com/user/repo) when you intend to
+#                            publish the project.
 #
 # Environment:
 #   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
 #   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
 #
 # Examples:
-#   # React / Python / Rust template (no --go-module-name needed):
-#   curl -sSL .../download.sh | sh -s -- react-spa ~/projects/my-app
+#   # Defaults — name and go-module-name both derived from <dest>:
+#   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app
 #
-#   # Go template (--go-module-name required):
+#   # Override go-module-name for a publishable module:
 #   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app \
 #     --go-module-name=github.com/me/my-app
 
@@ -120,14 +122,14 @@ esac
 parent=$(dirname "$dest")
 [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
-# Scaffolding is mandatory. Auto-derive the project name from <dest> if not
-# explicitly provided; require --go-module-name for go-* templates upfront so
-# the user learns about the missing flag before the network round-trip.
+# Scaffolding is mandatory. Auto-derive missing flags from <dest> so a single
+# positional argument is enough for the common case. Users who plan to publish
+# a Go module should pass --go-module-name=<canonical-path> explicitly.
 [ -z "$name" ] && name=$(basename "$dest")
 
 case "$template" in
   go-*)
-    [ -z "$module" ] && die "Go template '$template' requires --go-module-name=<path> (e.g., --go-module-name=github.com/user/repo)"
+    [ -z "$module" ] && module=$(basename "$dest")
     ;;
 esac
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,18 +1,15 @@
 #!/bin/sh
-# download.sh - Fetch a my-boilerplate template into a target directory.
+# download.sh - Fetch a my-boilerplate template and scaffold it as a usable
+# standalone project at a target directory.
 #
 # This script does NOT require my-boilerplate to be cloned locally. It
-# downloads the tarball at the requested ref, extracts only the requested
-# template directory, and either:
+# downloads the tarball at the requested ref, extracts the requested template
+# directory, and **always** delegates to the bundled scripts/scaffold/scaffold.sh
+# which rewrites template-name placeholders (Makefile, HTML, Go module path,
+# package.json name, etc.) so the result is immediately usable.
 #
-#   1. (default) copies the template as-is. Strings like "go-ssr-web" remain
-#      embedded in Makefile / go.mod / etc. Useful for "I just want to look
-#      at the files".
-#
-#   2. (with --name and/or --module) delegates to the bundled
-#      scripts/scaffold/scaffold.sh which rewrites template-name placeholders
-#      (Makefile, HTML, Go module path, package.json name, etc.) so the
-#      extracted directory is immediately usable as a standalone project.
+# Scaffolding is mandatory; there is no plain-copy mode. The premise of this
+# tool is "create a new project from a boilerplate", not "fetch raw files".
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
@@ -25,23 +22,23 @@
 #   <dest>       Destination directory (must not exist; parent must exist).
 #
 # Optional:
-#   --name=NAME       Enables scaffolding. Replaces template-name placeholders
-#                     with NAME. Defaults to basename(<dest>) when --module
-#                     is given without --name.
-#   --module=MODULE   Go module path (e.g., github.com/user/repo). Required
-#                     for go-* templates whenever scaffolding is enabled.
+#   --name=NAME       Project name written into Makefile / package.json / etc.
+#                     Defaults to basename(<dest>).
+#
+# Required for go-* templates:
+#   --module=MODULE   Go module path (e.g., github.com/user/repo).
 #
 # Environment:
 #   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
 #   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
 #
 # Examples:
-#   # Plain copy:
-#   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app
+#   # React / Python / Rust template (no --module needed):
+#   curl -sSL .../download.sh | sh -s -- react-spa ~/projects/my-app
 #
-#   # Full scaffolding (Go template):
+#   # Go template (--module required):
 #   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app \
-#     --name=my-app --module=github.com/me/my-app
+#     --module=github.com/me/my-app
 
 set -eu
 
@@ -122,26 +119,19 @@ esac
 parent=$(dirname "$dest")
 [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
-# Scaffold mode is enabled by --name and/or --module. In that mode the bundled
-# scripts/scaffold/scaffold.sh is invoked to rewrite placeholders (Makefile /
-# HTML / Go module path / package.json name etc.) so the result is a usable
-# standalone project. Without those flags we just copy the directory as-is.
-do_scaffold="no"
-if [ -n "$name" ] || [ -n "$module" ]; then
-  do_scaffold="yes"
-  [ -z "$name" ] && name=$(basename "$dest")
-fi
+# Scaffolding is mandatory. Auto-derive the project name from <dest> if not
+# explicitly provided; require --module for go-* templates upfront so the user
+# learns about the missing flag before the network round-trip.
+[ -z "$name" ] && name=$(basename "$dest")
 
 case "$template" in
   go-*)
-    if [ "$do_scaffold" = "yes" ] && [ -z "$module" ]; then
-      die "Go template '$template' requires --module=<path> when scaffolding"
-    fi
+    [ -z "$module" ] && die "Go template '$template' requires --module=<path>"
     ;;
 esac
 
-if [ "$do_scaffold" = "yes" ] && ! command -v bash >/dev/null 2>&1; then
-  die "bash is required for scaffolding (re-run without --name/--module for plain copy)"
+if ! command -v bash >/dev/null 2>&1; then
+  die "bash is required to run the bundled scripts/scaffold/scaffold.sh"
 fi
 
 tmpdir=$(mktemp -d)
@@ -162,8 +152,7 @@ tar -xzf "$tmpdir/repo.tar.gz" -C "$tmpdir"
 extracted=$(find "$tmpdir" -maxdepth 1 -type d -name 'my-boilerplate-*' | head -n1)
 [ -d "$extracted" ] || die "Extraction failed: tarball did not contain expected top-level directory"
 
-src="$extracted/$template"
-if [ ! -d "$src" ]; then
+if [ ! -d "$extracted/$template" ]; then
   # Build the available-template list dynamically from the extracted tarball
   # so it stays accurate as templates are added / renamed / removed. Filter
   # by the documented naming convention "<language>-<type>".
@@ -176,22 +165,16 @@ if [ ! -d "$src" ]; then
   die "Template '$template' not found at ${REPO}@${REF}. Available: $available"
 fi
 
-if [ "$do_scaffold" = "yes" ]; then
-  info "Scaffolding $template -> $dest (name=$name${module:+ module=$module})"
-  if [ -n "$module" ]; then
-    bash "$extracted/scripts/scaffold/scaffold.sh" \
-      "template=$template" "dest=$dest" "name=$name" "module=$module"
-  else
-    bash "$extracted/scripts/scaffold/scaffold.sh" \
-      "template=$template" "dest=$dest" "name=$name"
-  fi
+# Always invoke scaffold.sh. It rewrites template-name placeholders (Makefile /
+# HTML / Go module path / package.json name etc.) so the resulting directory
+# is a usable standalone project.
+info "Scaffolding $template -> $dest (name=$name${module:+ module=$module})"
+if [ -n "$module" ]; then
+  bash "$extracted/scripts/scaffold/scaffold.sh" \
+    "template=$template" "dest=$dest" "name=$name" "module=$module"
 else
-  info "Copying $template -> $dest (plain copy, no placeholder substitution)"
-  cp -R "$src" "$dest"
-  rm -f "$dest/docs/SYNC_FILES.md"
-  rmdir "$dest/docs" 2>/dev/null || true
-  warn "Project name '$template' is still embedded in source files."
-  warn "Re-run with --name (and --module for Go) to substitute placeholders."
+  bash "$extracted/scripts/scaffold/scaffold.sh" \
+    "template=$template" "dest=$dest" "name=$name"
 fi
 
 info "Done: $dest"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# download.sh - Download a my-boilerplate template to a target directory.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+#     | sh -s -- <template> <dest> [options]
+
+set -eu
+
+REPO="${MY_BOILERPLATE_REPO:-rengotaku/my-boilerplate}"
+REF="${MY_BOILERPLATE_REF:-main}"
+TARBALL_URL="https://github.com/${REPO}/archive/refs/heads/${REF}.tar.gz"
+
+VALID_TEMPLATES="go-cli go-rest-api go-graphql-api go-grpc-api go-ssr-web python-cli python-web react-spa react-spa-graphql react-spa-cloudflare rust-cli"
+
+if [ -t 2 ]; then
+  RED=$(printf '\033[0;31m')
+  GREEN=$(printf '\033[0;32m')
+  YELLOW=$(printf '\033[1;33m')
+  NC=$(printf '\033[0m')
+else
+  RED=""
+  GREEN=""
+  YELLOW=""
+  NC=""
+fi
+
+info() { printf "%s[INFO]%s %s\n" "$GREEN" "$NC" "$*" >&2; }
+warn() { printf "%s[WARN]%s %s\n" "$YELLOW" "$NC" "$*" >&2; }
+die() {
+  printf "%s[ERROR]%s %s\n" "$RED" "$NC" "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: download.sh <template> <dest> [options]
+
+Templates:
+$(for t in $VALID_TEMPLATES; do echo "  - $t"; done)
+
+Arguments:
+  <template>   Template name from the list above
+  <dest>       Destination directory (must not exist; parent must exist)
+
+Options:
+  --name=NAME       Project name (enables placeholder substitution).
+                    Defaults to basename of <dest> when --module is given.
+  --module=MODULE   Go module path (e.g., github.com/user/repo).
+                    Required for go-* templates when scaffolding is enabled.
+  -h, --help        Show this help.
+
+Environment:
+  MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate)
+  MY_BOILERPLATE_REF   Override ref / branch / tag (default: main)
+
+Examples:
+  # Plain copy (template name remains embedded in source files):
+  sh download.sh go-ssr-web ~/projects/my-app
+
+  # Full scaffolding (Go template):
+  sh download.sh go-ssr-web ~/projects/my-app \\
+    --name=my-app --module=github.com/me/my-app
+
+  # Via curl:
+  curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \\
+    | sh -s -- go-ssr-web ~/projects/my-app
+EOF
+}
+
+template=""
+dest=""
+name=""
+module=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --name=*) name="${1#--name=}" ;;
+    --module=*) module="${1#--module=}" ;;
+    --*) die "Unknown option: $1 (use --help)" ;;
+    *)
+      if [ -z "$template" ]; then
+        template="$1"
+      elif [ -z "$dest" ]; then
+        dest="$1"
+      else
+        die "Unexpected argument: $1"
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$template" ] || [ -z "$dest" ]; then
+  usage
+  exit 1
+fi
+
+valid=0
+for t in $VALID_TEMPLATES; do
+  if [ "$t" = "$template" ]; then
+    valid=1
+    break
+  fi
+done
+[ "$valid" -eq 1 ] || die "Invalid template: $template (use --help to list)"
+
+[ -e "$dest" ] && die "Destination already exists: $dest"
+parent=$(dirname "$dest")
+[ -d "$parent" ] || die "Parent directory does not exist: $parent"
+
+do_scaffold="no"
+if [ -n "$name" ] || [ -n "$module" ]; then
+  do_scaffold="yes"
+  [ -z "$name" ] && name=$(basename "$dest")
+fi
+
+case "$template" in
+  go-*)
+    if [ "$do_scaffold" = "yes" ] && [ -z "$module" ]; then
+      die "Go template '$template' requires --module=<path> when scaffolding"
+    fi
+    ;;
+esac
+
+if ! command -v bash >/dev/null 2>&1 && [ "$do_scaffold" = "yes" ]; then
+  die "bash is required for scaffolding (re-run without --name/--module for plain copy)"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+info "Downloading ${REPO}@${REF}..."
+if command -v curl >/dev/null 2>&1; then
+  curl -sSLf "$TARBALL_URL" -o "$tmpdir/repo.tar.gz" || die "Download failed: $TARBALL_URL"
+elif command -v wget >/dev/null 2>&1; then
+  wget -q "$TARBALL_URL" -O "$tmpdir/repo.tar.gz" || die "Download failed: $TARBALL_URL"
+else
+  die "curl or wget is required"
+fi
+
+info "Extracting..."
+tar -xzf "$tmpdir/repo.tar.gz" -C "$tmpdir"
+
+extracted=$(find "$tmpdir" -maxdepth 1 -type d -name 'my-boilerplate-*' | head -n1)
+[ -d "$extracted" ] || die "Extraction failed: tarball did not contain expected top-level directory"
+
+src="$extracted/$template"
+[ -d "$src" ] || die "Template directory not found in tarball: $template"
+
+if [ "$do_scaffold" = "yes" ]; then
+  info "Scaffolding $template -> $dest (name=$name${module:+ module=$module})"
+  if [ -n "$module" ]; then
+    bash "$extracted/scripts/scaffold/scaffold.sh" \
+      "template=$template" "dest=$dest" "name=$name" "module=$module"
+  else
+    bash "$extracted/scripts/scaffold/scaffold.sh" \
+      "template=$template" "dest=$dest" "name=$name"
+  fi
+else
+  info "Copying $template -> $dest (plain copy, no placeholder substitution)"
+  cp -R "$src" "$dest"
+  rm -f "$dest/docs/SYNC_FILES.md"
+  rmdir "$dest/docs" 2>/dev/null || true
+  warn "Project name '$template' is still embedded in source files."
+  warn "Re-run with --name (and --module for Go) to substitute placeholders."
+fi
+
+info "Done: $dest"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-#     | sh -s -- <template> <dest> [--name=NAME] [--module=MODULE]
+#     | sh -s -- <template> <dest> [--name=NAME] [--go-module-name=MODULE]
 #
 # Required:
 #   <template>   Template directory name (e.g., go-ssr-web, react-spa).
@@ -22,23 +22,24 @@
 #   <dest>       Destination directory (must not exist; parent must exist).
 #
 # Optional:
-#   --name=NAME       Project name written into Makefile / package.json / etc.
-#                     Defaults to basename(<dest>).
+#   --name=NAME              Project name written into Makefile /
+#                            package.json / etc. Defaults to basename(<dest>).
 #
 # Required for go-* templates:
-#   --module=MODULE   Go module path (e.g., github.com/user/repo).
+#   --go-module-name=MODULE  The value written into go.mod's `module` line
+#                            (e.g., github.com/user/repo).
 #
 # Environment:
 #   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
 #   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
 #
 # Examples:
-#   # React / Python / Rust template (no --module needed):
+#   # React / Python / Rust template (no --go-module-name needed):
 #   curl -sSL .../download.sh | sh -s -- react-spa ~/projects/my-app
 #
-#   # Go template (--module required):
+#   # Go template (--go-module-name required):
 #   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app \
-#     --module=github.com/me/my-app
+#     --go-module-name=github.com/me/my-app
 
 set -eu
 
@@ -67,7 +68,7 @@ die() {
 
 usage() {
   cat <<'EOF'
-Usage: download.sh <template> <dest> [--name=NAME] [--module=MODULE]
+Usage: download.sh <template> <dest> [--name=NAME] [--go-module-name=MODULE]
 
 See https://github.com/rengotaku/my-boilerplate#usage for full documentation.
 Run with an unknown <template> to see the currently available list.
@@ -86,7 +87,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     --name=*) name="${1#--name=}" ;;
-    --module=*) module="${1#--module=}" ;;
+    --go-module-name=*) module="${1#--go-module-name=}" ;;
     --*) die "Unknown option: $1 (see --help)" ;;
     *)
       if [ -z "$template" ]; then
@@ -120,13 +121,13 @@ parent=$(dirname "$dest")
 [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
 # Scaffolding is mandatory. Auto-derive the project name from <dest> if not
-# explicitly provided; require --module for go-* templates upfront so the user
-# learns about the missing flag before the network round-trip.
+# explicitly provided; require --go-module-name for go-* templates upfront so
+# the user learns about the missing flag before the network round-trip.
 [ -z "$name" ] && name=$(basename "$dest")
 
 case "$template" in
   go-*)
-    [ -z "$module" ] && die "Go template '$template' requires --module=<path>"
+    [ -z "$module" ] && die "Go template '$template' requires --go-module-name=<path> (e.g., --go-module-name=github.com/user/repo)"
     ;;
 esac
 
@@ -168,10 +169,10 @@ fi
 # Always invoke scaffold.sh. It rewrites template-name placeholders (Makefile /
 # HTML / Go module path / package.json name etc.) so the resulting directory
 # is a usable standalone project.
-info "Scaffolding $template -> $dest (name=$name${module:+ module=$module})"
+info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module})"
 if [ -n "$module" ]; then
   bash "$extracted/scripts/scaffold/scaffold.sh" \
-    "template=$template" "dest=$dest" "name=$name" "module=$module"
+    "template=$template" "dest=$dest" "name=$name" "go-module-name=$module"
 else
   bash "$extracted/scripts/scaffold/scaffold.sh" \
     "template=$template" "dest=$dest" "name=$name"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,17 +1,53 @@
 #!/bin/sh
-# download.sh - Download a my-boilerplate template to a target directory.
+# download.sh - Fetch a my-boilerplate template into a target directory.
+#
+# This script does NOT require my-boilerplate to be cloned locally. It
+# downloads the tarball at the requested ref, extracts only the requested
+# template directory, and either:
+#
+#   1. (default) copies the template as-is. Strings like "go-ssr-web" remain
+#      embedded in Makefile / go.mod / etc. Useful for "I just want to look
+#      at the files".
+#
+#   2. (with --name and/or --module) delegates to the bundled
+#      scripts/scaffold/scaffold.sh which rewrites template-name placeholders
+#      (Makefile, HTML, Go module path, package.json name, etc.) so the
+#      extracted directory is immediately usable as a standalone project.
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-#     | sh -s -- <template> <dest> [options]
+#     | sh -s -- <template> <dest> [--name=NAME] [--module=MODULE]
+#
+# Required:
+#   <template>   Template directory name (e.g., go-ssr-web, react-spa).
+#                Validated against the actual contents of the downloaded
+#                tarball; an unknown name prints the available list.
+#   <dest>       Destination directory (must not exist; parent must exist).
+#
+# Optional:
+#   --name=NAME       Enables scaffolding. Replaces template-name placeholders
+#                     with NAME. Defaults to basename(<dest>) when --module
+#                     is given without --name.
+#   --module=MODULE   Go module path (e.g., github.com/user/repo). Required
+#                     for go-* templates whenever scaffolding is enabled.
+#
+# Environment:
+#   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
+#   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
+#
+# Examples:
+#   # Plain copy:
+#   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app
+#
+#   # Full scaffolding (Go template):
+#   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app \
+#     --name=my-app --module=github.com/me/my-app
 
 set -eu
 
 REPO="${MY_BOILERPLATE_REPO:-rengotaku/my-boilerplate}"
 REF="${MY_BOILERPLATE_REF:-main}"
 TARBALL_URL="https://github.com/${REPO}/archive/refs/heads/${REF}.tar.gz"
-
-VALID_TEMPLATES="go-cli go-rest-api go-graphql-api go-grpc-api go-ssr-web python-cli python-web react-spa react-spa-graphql react-spa-cloudflare rust-cli"
 
 if [ -t 2 ]; then
   RED=$(printf '\033[0;31m')
@@ -33,38 +69,11 @@ die() {
 }
 
 usage() {
-  cat <<EOF
-Usage: download.sh <template> <dest> [options]
+  cat <<'EOF'
+Usage: download.sh <template> <dest> [--name=NAME] [--module=MODULE]
 
-Templates:
-$(for t in $VALID_TEMPLATES; do echo "  - $t"; done)
-
-Arguments:
-  <template>   Template name from the list above
-  <dest>       Destination directory (must not exist; parent must exist)
-
-Options:
-  --name=NAME       Project name (enables placeholder substitution).
-                    Defaults to basename of <dest> when --module is given.
-  --module=MODULE   Go module path (e.g., github.com/user/repo).
-                    Required for go-* templates when scaffolding is enabled.
-  -h, --help        Show this help.
-
-Environment:
-  MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate)
-  MY_BOILERPLATE_REF   Override ref / branch / tag (default: main)
-
-Examples:
-  # Plain copy (template name remains embedded in source files):
-  sh download.sh go-ssr-web ~/projects/my-app
-
-  # Full scaffolding (Go template):
-  sh download.sh go-ssr-web ~/projects/my-app \\
-    --name=my-app --module=github.com/me/my-app
-
-  # Via curl:
-  curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \\
-    | sh -s -- go-ssr-web ~/projects/my-app
+See https://github.com/rengotaku/my-boilerplate#usage for full documentation.
+Run with an unknown <template> to see the currently available list.
 EOF
 }
 
@@ -81,7 +90,7 @@ while [ $# -gt 0 ]; do
       ;;
     --name=*) name="${1#--name=}" ;;
     --module=*) module="${1#--module=}" ;;
-    --*) die "Unknown option: $1 (use --help)" ;;
+    --*) die "Unknown option: $1 (see --help)" ;;
     *)
       if [ -z "$template" ]; then
         template="$1"
@@ -100,19 +109,23 @@ if [ -z "$template" ] || [ -z "$dest" ]; then
   exit 1
 fi
 
-valid=0
-for t in $VALID_TEMPLATES; do
-  if [ "$t" = "$template" ]; then
-    valid=1
-    break
-  fi
-done
-[ "$valid" -eq 1 ] || die "Invalid template: $template (use --help to list)"
+# Sanity-check the template token before hitting the network. The authoritative
+# validation happens after extraction (against the actual tarball contents) so
+# that template additions / renames / removals do not require editing this file.
+case "$template" in
+  *[!a-zA-Z0-9_-]* | "" | -*)
+    die "Invalid template name: $template"
+    ;;
+esac
 
 [ -e "$dest" ] && die "Destination already exists: $dest"
 parent=$(dirname "$dest")
 [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
+# Scaffold mode is enabled by --name and/or --module. In that mode the bundled
+# scripts/scaffold/scaffold.sh is invoked to rewrite placeholders (Makefile /
+# HTML / Go module path / package.json name etc.) so the result is a usable
+# standalone project. Without those flags we just copy the directory as-is.
 do_scaffold="no"
 if [ -n "$name" ] || [ -n "$module" ]; then
   do_scaffold="yes"
@@ -127,7 +140,7 @@ case "$template" in
     ;;
 esac
 
-if ! command -v bash >/dev/null 2>&1 && [ "$do_scaffold" = "yes" ]; then
+if [ "$do_scaffold" = "yes" ] && ! command -v bash >/dev/null 2>&1; then
   die "bash is required for scaffolding (re-run without --name/--module for plain copy)"
 fi
 
@@ -150,7 +163,18 @@ extracted=$(find "$tmpdir" -maxdepth 1 -type d -name 'my-boilerplate-*' | head -
 [ -d "$extracted" ] || die "Extraction failed: tarball did not contain expected top-level directory"
 
 src="$extracted/$template"
-[ -d "$src" ] || die "Template directory not found in tarball: $template"
+if [ ! -d "$src" ]; then
+  # Build the available-template list dynamically from the extracted tarball
+  # so it stays accurate as templates are added / renamed / removed. Filter
+  # by the documented naming convention "<language>-<type>".
+  available=$(
+    cd "$extracted" && \
+      find . -mindepth 1 -maxdepth 1 -type d \
+        \( -name 'go-*' -o -name 'python-*' -o -name 'react-*' -o -name 'rust-*' \) \
+        -exec basename {} \; | sort | tr '\n' ' '
+  )
+  die "Template '$template' not found at ${REPO}@${REF}. Available: $available"
+fi
 
 if [ "$do_scaffold" = "yes" ]; then
   info "Scaffolding $template -> $dest (name=$name${module:+ module=$module})"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-#     | sh -s -- <template> <dest> [--name=NAME] [--go-module-name=MODULE]
+#     | sh -s -- <template> <dest> [--name=NAME]
 #
 # Required:
 #   <template>   Template directory name (e.g., go-ssr-web, react-spa).
@@ -22,26 +22,21 @@
 #   <dest>       Destination directory (must not exist; parent must exist).
 #
 # Optional:
-#   --name=NAME              Project name written into Makefile /
-#                            package.json / etc. Defaults to basename(<dest>).
-#   --go-module-name=MODULE  Value written into go.mod's `module` line for
-#                            go-* templates. Defaults to basename(<dest>),
-#                            which produces a local-only module suitable for
-#                            prototyping. Pass an explicit canonical path
-#                            (e.g., github.com/user/repo) when you intend to
-#                            publish the project.
+#   --name=NAME  Project name written into Makefile / package.json / etc.
+#                Defaults to basename(<dest>).
+#
+# Go templates: the `module` line in go.mod is auto-set to basename(<dest>),
+# producing a local-only module suitable for prototyping. If you plan to
+# publish the project, edit go.mod after scaffolding:
+#   go mod edit -module github.com/<user>/<repo>
+# The Next steps message printed by scaffold.sh repeats this hint.
 #
 # Environment:
 #   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
 #   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
 #
-# Examples:
-#   # Defaults — name and go-module-name both derived from <dest>:
+# Example:
 #   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app
-#
-#   # Override go-module-name for a publishable module:
-#   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app \
-#     --go-module-name=github.com/me/my-app
 
 set -eu
 
@@ -70,7 +65,7 @@ die() {
 
 usage() {
   cat <<'EOF'
-Usage: download.sh <template> <dest> [--name=NAME] [--go-module-name=MODULE]
+Usage: download.sh <template> <dest> [--name=NAME]
 
 See https://github.com/rengotaku/my-boilerplate#usage for full documentation.
 Run with an unknown <template> to see the currently available list.
@@ -80,7 +75,6 @@ EOF
 template=""
 dest=""
 name=""
-module=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -89,7 +83,6 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     --name=*) name="${1#--name=}" ;;
-    --go-module-name=*) module="${1#--go-module-name=}" ;;
     --*) die "Unknown option: $1 (see --help)" ;;
     *)
       if [ -z "$template" ]; then
@@ -122,15 +115,15 @@ esac
 parent=$(dirname "$dest")
 [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
-# Scaffolding is mandatory. Auto-derive missing flags from <dest> so a single
-# positional argument is enough for the common case. Users who plan to publish
-# a Go module should pass --go-module-name=<canonical-path> explicitly.
+# Scaffolding is mandatory. Auto-derive name from <dest> so a single positional
+# argument is enough for the common case. For go-* templates we also derive a
+# local-only module name; users who plan to publish should run
+# `go mod edit -module github.com/<user>/<repo>` after scaffolding.
 [ -z "$name" ] && name=$(basename "$dest")
 
+module=""
 case "$template" in
-  go-*)
-    [ -z "$module" ] && module=$(basename "$dest")
-    ;;
+  go-*) module=$(basename "$dest") ;;
 esac
 
 if ! command -v bash >/dev/null 2>&1; then

--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -107,11 +107,14 @@ validate_name() {
   fi
 }
 
-# Validate Go module path format
+# Validate Go module path format. Accepts both:
+#   - canonical path form (e.g., github.com/user/repo) for publishable modules
+#   - single-token form (e.g., my-app) for local-only modules
+# Both are valid `module` declarations in go.mod.
 validate_module() {
   local module="$1"
-  if [[ ! "$module" =~ ^[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)+$ ]]; then
-    die "Invalid module path: $module (expected format: github.com/<user>/<repo>)"
+  if [[ ! "$module" =~ ^[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*$ ]]; then
+    die "Invalid module path: $module"
   fi
 }
 

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -116,6 +116,9 @@ case "$family" in
     echo "  cd $dest"
     echo "  go mod tidy"
     echo "  make ci"
+    echo ""
+    echo "Publishing this module? Update go.mod's module line to a canonical path:"
+    echo "  go mod edit -module github.com/<user>/<repo>"
     ;;
   react)
     echo "  cd $dest"

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -2,7 +2,10 @@
 # Scaffold a standalone project from a monorepo template
 #
 # Usage:
-#   bash scripts/scaffold/scaffold.sh template=<name> dest=<path> name=<project-name> [module=<go-module>]
+#   bash scripts/scaffold/scaffold.sh template=<name> dest=<path> name=<project-name> [go-module-name=<go-module>]
+#
+# go-module-name は Go テンプレートのみで必須。`go.mod` の `module` 行に書かれる
+# モジュールパス（例: github.com/user/repo）を指定する。
 
 set -euo pipefail
 
@@ -23,7 +26,7 @@ for arg in "$@"; do
     template=*) template="${arg#template=}" ;;
     dest=*) dest="${arg#dest=}" ;;
     name=*) name="${arg#name=}" ;;
-    module=*) module="${arg#module=}" ;;
+    go-module-name=*) module="${arg#go-module-name=}" ;;
     *) die "Unknown argument: $arg" ;;
   esac
 done
@@ -39,15 +42,15 @@ validate_dest "$dest"
 
 family="$(detect_family "$template")"
 
-# Go templates require module=
+# Go templates require go-module-name= (the value written into go.mod's `module` line)
 if [[ "$family" == "go" ]]; then
-  [[ -z "$module" ]] && die "Go templates require module= argument (e.g., module=github.com/user/repo)"
+  [[ -z "$module" ]] && die "Go templates require go-module-name= argument (e.g., go-module-name=github.com/user/repo)"
   validate_module "$module"
 fi
 
-# Non-Go templates: warn if module is provided
+# Non-Go templates: warn if go-module-name is provided
 if [[ "$family" != "go" && -n "$module" ]]; then
-  warn "module= is ignored for $family templates"
+  warn "go-module-name= is ignored for $family templates"
   module=""
 fi
 


### PR DESCRIPTION
## Summary

`my-boilerplate` をローカルにクローンしていなくても、curl ワンライナー 1 本で任意のテンプレートを指定ディレクトリへ展開できる `scripts/download.sh` を追加する。

## What / Why / How

**What:**

- `scripts/download.sh` 新規追加（POSIX sh、curl pipe to sh で動作）
- `README.md` の Usage を curl ワンライナー手順に書き換え
- `CLAUDE.md` に「テンプレート利用時は構造模倣せず必ず download.sh でコピー」を明記

**Why:**

- Issue #105: モノリポのサブディレクトリ構造のため `git clone` だけでは使えず、ファイル取得手順が煩雑だった
- Issue #97 の根本原因の 1 つ（取得が面倒なので「構造だけ真似る」へ流れる）にも効く

**How:**

- GitHub の tarball (`archive/refs/heads/main.tar.gz`) を一時ディレクトリへ取得
- `tar -xz` で展開し、指定テンプレートディレクトリだけを `<dest>` へコピー
- `--name` / `--module` 指定時は既存 `scripts/scaffold/scaffold.sh` を内部で呼んで placeholder 置換
- フォーク利用向けに `MY_BOILERPLATE_REPO` / `MY_BOILERPLATE_REF` 環境変数を追加

## 確認方法

```bash
# Plain copy
TMP=$(mktemp -d)
sh scripts/download.sh python-cli "$TMP/my-app"
ls "$TMP/my-app"   # → LICENSE Makefile pyproject.toml README.md src tests

# Scaffold (Go テンプレートは module 必須)
sh scripts/download.sh go-cli "$TMP/my-go-app" --module=github.com/me/my-go-app

# エラーパス
sh scripts/download.sh bogus /tmp/x       # → Invalid template
sh scripts/download.sh go-cli /tmp        # → Destination already exists
sh scripts/download.sh go-cli /tmp/x --name=x  # → Go requires --module
```

PR マージ後の利用イメージ:

```bash
curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
  | sh -s -- go-ssr-web ~/projects/my-app --module=github.com/me/my-app
```

## Checklist

- [x] `make check` が通ること（影響なし: スクリプト追加のみ）
- [x] 必要に応じてテストを追加（ローカルで plain copy / エラーパスを動作確認済み）
- [x] 必要に応じてドキュメントを更新（README, CLAUDE.md）

## 関連Issue

Closes #105
Refs #97