### PR TITLE
feat(scaffold): go-react-spa composite テンプレ対応 (#114)

### DIFF
--- a/.github/workflows/go-react-spa.yml
+++ b/.github/workflows/go-react-spa.yml
@@ -1,0 +1,103 @@
+name: go-react-spa CI
+
+# go-react-spa is a composite template (Go monolith embedding the react-spa
+# SPA via .compose.toml + frontend.overlay/). It is fragile to changes in
+# either side, so this workflow exercises the full compose -> install ->
+# ci -> build -> smoke-test pipeline whenever go-react-spa/, the react-spa
+# base template, or this workflow itself is modified.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'go-react-spa/**'
+      - 'react-spa/**'
+      - '.github/workflows/go-react-spa.yml'
+  pull_request:
+    paths:
+      - 'go-react-spa/**'
+      - 'react-spa/**'
+      - '.github/workflows/go-react-spa.yml'
+
+defaults:
+  run:
+    working-directory: go-react-spa
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go-react-spa/go.mod
+          cache-dependency-path: go-react-spa/go.sum
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: react-spa/.node-version
+          cache: 'npm'
+          cache-dependency-path: react-spa/package-lock.json
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+
+      - name: Compose frontend (react-spa base + overlay)
+        run: make compose
+
+      - name: Install dependencies (Go modules + npm ci)
+        run: make install
+
+      - name: Lint and test (Go + frontend)
+        run: make ci
+
+      - name: Build monolithic binary (frontend bundle embedded into Go)
+        run: make build
+
+      - name: Verify no dev-host leak in production bundle
+        run: |
+          if grep -R --include='*.js' --include='*.css' --include='*.html' \
+               'localhost:8080' internal/static/dist/ 2>/dev/null; then
+            echo "ERROR: 'localhost:8080' leaked into production bundle"
+            exit 1
+          fi
+
+      - name: Smoke test — binary serves SPA + API
+        run: |
+          set -euo pipefail
+          PORT=18091 ./bin/server >/tmp/server.log 2>&1 &
+          server_pid=$!
+          trap "kill $server_pid 2>/dev/null || true" EXIT
+
+          # Wait for server ready (up to ~10s)
+          for _ in $(seq 1 20); do
+            if curl -sSf -o /dev/null http://localhost:18091/api/v1/users; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          fail=0
+          check() {
+            local path="$1" expected="$2" label="$3"
+            local got
+            got=$(curl -sS -o /dev/null -w '%{http_code}' "http://localhost:18091${path}")
+            if [ "$got" = "$expected" ]; then
+              echo "OK  $label  GET $path -> $got"
+            else
+              echo "FAIL $label  GET $path -> $got (expected $expected)"
+              fail=1
+            fi
+          }
+          check "/"             200 "SPA index"
+          check "/api/v1/users" 200 "API"
+          check "/users"        200 "SPA fallback"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "--- server log ---"
+            cat /tmp/server.log || true
+            exit 1
+          fi

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -163,7 +163,10 @@ fi
 
 # Always invoke scaffold.sh. It rewrites template-name placeholders (Makefile /
 # HTML / Go module path / package.json name etc.) so the resulting directory
-# is a usable standalone project.
+# is a usable standalone project. Composite templates (those that ship a
+# `.compose.toml`, e.g. go-react-spa) read sibling templates from $extracted
+# during scaffolding, so the full tarball must remain available — do not
+# pre-trim it down to $extracted/$template here.
 info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module})"
 if [ -n "$module" ]; then
   bash "$extracted/scripts/scaffold/scaffold.sh" \

--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -9,6 +9,7 @@ VALID_TEMPLATES=(
   go-graphql-api
   go-grpc-api
   go-ssr-web
+  go-react-spa
   go-cli
   react-spa
   react-spa-graphql
@@ -18,12 +19,14 @@ VALID_TEMPLATES=(
   rust-cli
 )
 
-# Artifacts to remove after copy
+# Artifacts to remove after copy.
+# NOTE: every entry is matched by `find -name <entry>` against the dest tree
+# (depth ≤ 2). Avoid generic words that collide with source paths — e.g.
+# `server` would also match Go templates' `cmd/server/` source directory.
 ARTIFACTS=(
   node_modules
   .venv
   target
-  server
   dist
   .vite
   bin
@@ -33,6 +36,8 @@ ARTIFACTS=(
   .ruff_cache
   coverage
   .coverage
+  coverage.out
+  tmp
 )
 
 # Colors

--- a/scripts/scaffold/lib/compose.sh
+++ b/scripts/scaffold/lib/compose.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Composite-template support.
+#
+# Some templates ship a `.compose.toml` manifest that declares another
+# template as a base plus an overlay directory of monolith-specific
+# diffs. `compose_template` reads that manifest and materializes the
+# merged tree at scaffold time so the resulting project does not depend
+# on the parent monorepo siblings.
+
+# Output globals from parse_compose_toml
+COMPOSE_BASE_TEMPLATE=""
+COMPOSE_BASE_DEST=""
+COMPOSE_OVERLAY_SRC=""
+COMPOSE_OVERLAY_DEST=""
+COMPOSE_PACKAGE_NAME=""
+
+# parse_compose_toml <manifest>
+#
+# Minimal TOML reader sufficient for go-react-spa/.compose.toml.
+# Recognises: `[section]` headers and `key = "value"` string assignments.
+parse_compose_toml() {
+  local manifest="$1"
+  COMPOSE_BASE_TEMPLATE=""
+  COMPOSE_BASE_DEST=""
+  COMPOSE_OVERLAY_SRC=""
+  COMPOSE_OVERLAY_DEST=""
+  COMPOSE_PACKAGE_NAME=""
+
+  local section="" line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    [[ "${line:0:1}" == "#" ]] && continue
+    if [[ "$line" =~ ^\[([a-zA-Z_]+)\]$ ]]; then
+      section="${BASH_REMATCH[1]}"
+      continue
+    fi
+    if [[ "$line" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*=[[:space:]]*\"([^\"]*)\"$ ]]; then
+      key="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+      case "${section}.${key}" in
+        base.template) COMPOSE_BASE_TEMPLATE="$value" ;;
+        base.dest) COMPOSE_BASE_DEST="$value" ;;
+        overlay.src) COMPOSE_OVERLAY_SRC="$value" ;;
+        overlay.dest) COMPOSE_OVERLAY_DEST="$value" ;;
+        post.package_name) COMPOSE_PACKAGE_NAME="$value" ;;
+      esac
+    fi
+  done < "$manifest"
+}
+
+# compose_template <dest> <repo_root> [package_name_override]
+#
+# If <dest>/.compose.toml exists, materializes <dest>/<base.dest>/ from
+# <repo_root>/<base.template>/ + <dest>/<overlay.src>/. After merging,
+# the manifest and overlay directory are removed and the in-tree
+# Makefile is stripped of compose-only machinery so the scaffold result
+# is a self-contained project.
+compose_template() {
+  local dest="$1"
+  local repo_root="$2"
+  local override="${3:-}"
+
+  local manifest="$dest/.compose.toml"
+  [[ -f "$manifest" ]] || return 0
+
+  parse_compose_toml "$manifest"
+
+  [[ -z "$COMPOSE_BASE_TEMPLATE" ]] && die "[compose] $manifest: missing [base].template"
+  [[ -z "$COMPOSE_BASE_DEST" ]] && die "[compose] $manifest: missing [base].dest"
+  [[ -z "$COMPOSE_OVERLAY_SRC" ]] && die "[compose] $manifest: missing [overlay].src"
+  [[ -z "$COMPOSE_OVERLAY_DEST" ]] && die "[compose] $manifest: missing [overlay].dest"
+
+  local base_src="$repo_root/$COMPOSE_BASE_TEMPLATE"
+  local base_dest="$dest/$COMPOSE_BASE_DEST"
+  local overlay_src="$dest/$COMPOSE_OVERLAY_SRC"
+  local overlay_dest="$dest/$COMPOSE_OVERLAY_DEST"
+
+  [[ -d "$base_src" ]] || die "[compose] base template not found: $base_src"
+  [[ -d "$overlay_src" ]] || die "[compose] overlay source not found: $overlay_src"
+
+  if ! command -v rsync >/dev/null 2>&1; then
+    die "[compose] rsync is required"
+  fi
+
+  info "[compose] base: $COMPOSE_BASE_TEMPLATE -> $COMPOSE_BASE_DEST"
+  rm -rf "$base_dest"
+  mkdir -p "$base_dest"
+  rsync -a \
+    --exclude='node_modules' --exclude='dist' --exclude='coverage' \
+    --exclude='.claude' --exclude='.git' \
+    "$base_src/" "$base_dest/"
+
+  info "[compose] overlay: $COMPOSE_OVERLAY_SRC -> $COMPOSE_OVERLAY_DEST"
+  rsync -a "$overlay_src/" "$overlay_dest/"
+
+  local pkg_name="${override:-$COMPOSE_PACKAGE_NAME}"
+  if [[ -n "$pkg_name" ]]; then
+    if [[ -f "$base_dest/package.json" ]]; then
+      info "[compose] post: package.json name -> $pkg_name"
+      if command -v node >/dev/null 2>&1; then
+        node -e 'const fs=require("fs");const f=process.argv[1];const p=JSON.parse(fs.readFileSync(f,"utf8"));p.name=process.argv[2];fs.writeFileSync(f,JSON.stringify(p,null,2)+"\n");' \
+          "$base_dest/package.json" "$pkg_name"
+      else
+        # Fallback: sed-edit the "name" field. Keeps formatting roughly intact.
+        sed -i "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package.json"
+      fi
+    fi
+    if [[ -f "$base_dest/package-lock.json" ]]; then
+      sed -i "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package-lock.json"
+    fi
+  fi
+
+  # Idempotency marker so an in-tree `make compose` after scaffolding is a no-op.
+  touch "$base_dest/.composed"
+
+  rm -f "$manifest"
+  rm -rf "$overlay_src"
+
+  if [[ -f "$dest/Makefile" ]]; then
+    strip_compose_makefile "$dest/Makefile"
+  fi
+}
+
+# strip_compose_makefile <Makefile path>
+#
+# Removes BASE_TEMPLATE_DIR / overlay / verify machinery so the
+# scaffolded Makefile stands alone (no `../<base-template>` siblings,
+# no `frontend.overlay/` source).
+strip_compose_makefile() {
+  local makefile="$1"
+  local tmp
+  tmp="$(mktemp)"
+
+  awk '
+    BEGIN { skip_block = 0 }
+
+    # End any in-progress block when we see a non-tab top-level line
+    # (recipes are indented with TAB; everything else terminates a rule).
+    skip_block && /^[^\t]/ { skip_block = 0 }
+    skip_block { next }
+
+    # Drop entire blocks: $(COMPOSED_MARKER), compose-clean, verify
+    /^\$\(COMPOSED_MARKER\):/ { skip_block = 1; next }
+    /^## compose-clean:/ { skip_block = 1; next }
+    /^compose-clean:/ { skip_block = 1; next }
+    /^## verify:/ { skip_block = 1; next }
+    /^verify:/ { skip_block = 1; next }
+
+    # Drop composite-only variables and the section comment
+    /^# Composite-template config/ { next }
+    /^BASE_TEMPLATE_DIR / { next }
+    /^OVERLAY_DIR / { next }
+    /^COMPOSED_MARKER / { next }
+    /^PACKAGE_NAME / { next }
+
+    # Drop the .PHONY continuation line that lists compose / compose-clean / verify
+    /^\tcompose compose-clean verify \\$/ { next }
+
+    # Strip `compose` dep from any rule (e.g. `install: compose` -> `install:`)
+    /^[a-zA-Z][a-zA-Z0-9_-]*: compose([[:space:]]|$)/ {
+      sub(/: compose([[:space:]]+|$)/, ": ")
+      sub(/[ \t]+$/, "")
+      print
+      next
+    }
+
+    # Update install docstring (compose preamble no longer applies)
+    /^## install: Compose frontend, then install Go modules/ {
+      print "## install: Install Go modules and frontend deps"
+      next
+    }
+
+    # Replace compose docstring + rule with a no-op (frontend/ is pre-composed)
+    /^## compose:/ {
+      print "## compose: No-op (frontend/ pre-composed during scaffold)"
+      next
+    }
+    /^compose: \$\(COMPOSED_MARKER\)/ {
+      print "compose: ;"
+      next
+    }
+
+    { print }
+  ' "$makefile" > "$tmp"
+
+  mv "$tmp" "$makefile"
+}

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -58,6 +58,15 @@ fi
 info "Copying template '$template' to '$dest'..."
 copy_template "$REPO_ROOT/$template" "$dest"
 
+# --- Composite-template merge (runs before family replacements so the
+#     materialized base tree is visible to subsequent steps). ---
+if [[ -f "$dest/.compose.toml" ]]; then
+  info "Composing template '$template' (manifest: .compose.toml)..."
+  # shellcheck source=lib/compose.sh
+  source "$SCRIPT_DIR/lib/compose.sh"
+  compose_template "$dest" "$REPO_ROOT" "$name"
+fi
+
 # --- CI workflow transformation (before family replacements so they can process CI files too) ---
 info "Transforming CI workflows..."
 source "$SCRIPT_DIR/lib/ci.sh"
@@ -114,8 +123,17 @@ echo "Next steps:"
 case "$family" in
   go)
     echo "  cd $dest"
-    echo "  go mod tidy"
-    echo "  make ci"
+    if [[ "$template" == "go-react-spa" ]]; then
+      # Composite template: `make install` runs `go mod download` + `npm ci`
+      # against the pre-composed frontend/, then `make build` produces a
+      # single Go binary embedding the SPA bundle.
+      echo "  make install"
+      echo "  make build"
+      echo "  ./bin/server"
+    else
+      echo "  go mod tidy"
+      echo "  make ci"
+    fi
     echo ""
     echo "Publishing this module? Update go.mod's module line to a canonical path:"
     echo "  go mod edit -module github.com/<user>/<repo>"


### PR DESCRIPTION
## Summary

`scripts/scaffold/scaffold.sh` と `scripts/download.sh` を拡張し、`go-react-spa` のような **コンポジット構成テンプレート**（`.compose.toml` でベース＋オーバーレイを宣言する形式）を scaffold できるようにする。

## What / Why / How

**What:**

- `scripts/scaffold/lib/compose.sh` を新設
- `scripts/scaffold/scaffold.sh` から `compose_template` を呼び出すフックを追加
- `scripts/scaffold/lib/common.sh` の `VALID_TEMPLATES` に `go-react-spa` を追加
- `scripts/download.sh` にコンポジット要件のコメント追記（コード変更なし）
- 副次的に `ARTIFACTS` から `server` を削除（pre-existing バグ修正）

**Why:**

- Issue #114 / 設計: #82 [build-tag 分離方式](https://github.com/rengotaku/my-boilerplate/issues/82#issuecomment-4323277368) ＋ PR #116 で導入したコンポジット構成
- これまで `go-react-spa` は `download.sh`/`scaffold.sh` 経由では `Unknown template` で die、突破しても `frontend/` が合成されず `make build` 不能だった
- `scaffold.sh` 経由で「download → make install → make build → ./bin/server」が一発で通る状態にする

**How:**

- `compose.sh::parse_compose_toml` が `.compose.toml` を読み（`[section]` ＋ `key = "value"` のみ対応の最小 TOML パーサ）
- `compose.sh::compose_template` が:
  1. ベース `<repo_root>/<base.template>/` → `<dest>/<base.dest>/` へ rsync (`node_modules` / `dist` / `coverage` / `.claude` / `.git` 除外)
  2. オーバーレイ `<dest>/<overlay.src>/` → `<dest>/<overlay.dest>/` へ重ね書き
  3. `package.json` / `package-lock.json` の `name` を scaffold の `name` 引数で置換
  4. `frontend/.composed` マーカーを touch して in-tree `make compose` を冪等化
  5. `.compose.toml` と `<overlay.src>/` を削除
  6. `strip_compose_makefile` が awk で `BASE_TEMPLATE_DIR` / `$(COMPOSED_MARKER)` ルール / `compose-clean:` / `verify:` ターゲット / 各 target の `compose` 依存 / `.PHONY` 連結行から compose 系トークンを除去

- `scaffold.sh` は `copy_template` 直後・CI 変換とファミリ別置換の前に `[[ -f "$dest/.compose.toml" ]]` ガードで `compose.sh` を source して呼び出し
- `go-react-spa` の Next steps を `make install && make build && ./bin/server` に
- `download.sh` は `\$extracted` 全体を保持しているため `\$REPO_ROOT` 経由でベースに到達でき、コード変更不要（コメントのみ追記）

### 副次的バグ修正: `server` artifact

`common.sh::ARTIFACTS` の `server` エントリは `find -name server -maxdepth 2` で **すべての Go テンプレート の `cmd/server/`** ソースディレクトリも削除していた。`bin/` がバイナリ削除を担当するため redundant。今回 #114 検証で初めて `make build` を実行して発見した既存バグ。

## 確認方法

\`\`\`bash
# 1. scaffold パスウェイ
rm -rf /tmp/test-monolith
bash scripts/scaffold/scaffold.sh \\
  template=go-react-spa dest=/tmp/test-monolith \\
  name=test-monolith go-module-name=test-monolith
cd /tmp/test-monolith
make install && make build
PORT=18091 ./bin/server &
sleep 2
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/             # 200
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/api/v1/users # 200
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/users        # 200 (SPA fallback)
lsof -ti :18091 | xargs -r kill

# 2. download.sh パスウェイ（マージ後）
curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \\
  | sh -s -- go-react-spa /tmp/test-download
cd /tmp/test-download && make install && make build && ./bin/server

# 3. regression: go-rest-api scaffold + build
rm -rf /tmp/test-rest
bash scripts/scaffold/scaffold.sh \\
  template=go-rest-api dest=/tmp/test-rest name=test-rest go-module-name=test-rest
cd /tmp/test-rest && go build ./...

# 4. source-tree make verify (scaffold-pathway smoke)
cd go-react-spa && make verify
\`\`\`

すべて green を確認済み。本番バンドル js への \`localhost:8080\` リテラル混入も grep ヒット 0。

## Checklist

- [x] \`make check\` が通ること（go-react-spa の \`make verify\` で確認）
- [x] 必要に応じてテストを追加（手動 e2e ログを上に記載）
- [ ] 必要に応じてドキュメントを更新

## 関連Issue

Closes #114

Unblocks #115 (\`scaffold-verify.yml\` matrix への go-react-spa 追加)