### PR TITLE
ci(go-react-spa): scaffold-verify への追加と README 整備 (Issue #115)

### DIFF
--- a/.github/workflows/scaffold-verify.yml
+++ b/.github/workflows/scaffold-verify.yml
@@ -10,6 +10,7 @@ on:
       - 'go-grpc-api/**'
       - 'go-ssr-web/**'
       - 'go-cli/**'
+      - 'go-react-spa/**'
       - 'react-spa/**'
       - 'react-spa-graphql/**'
       - 'react-spa-cloudflare/**'
@@ -25,6 +26,7 @@ on:
       - 'go-grpc-api/**'
       - 'go-ssr-web/**'
       - 'go-cli/**'
+      - 'go-react-spa/**'
       - 'react-spa/**'
       - 'react-spa-graphql/**'
       - 'react-spa-cloudflare/**'
@@ -69,6 +71,89 @@ jobs:
         run: |
           go mod tidy
           make ci
+
+  scaffold-go-react-spa:
+    # Composite template: scaffold runs `.compose.toml` to merge react-spa
+    # base + frontend.overlay/ into frontend/. Verifies the full
+    # scaffold -> install -> build -> binary-serves-SPA pipeline.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go-react-spa/go.mod
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: react-spa/.node-version
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+
+      - name: Scaffold project
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=go-react-spa \
+            dest=/tmp/test-go-react-spa \
+            name=test-go-react-spa \
+            go-module-name=github.com/test/test-go-react-spa
+
+      - name: Install dependencies (Go modules + npm ci)
+        working-directory: /tmp/test-go-react-spa
+        run: make install
+
+      - name: Build monolithic binary (frontend bundle embedded into Go)
+        working-directory: /tmp/test-go-react-spa
+        run: make build
+
+      - name: Verify no dev-host leak in production bundle
+        working-directory: /tmp/test-go-react-spa
+        run: |
+          if grep -R --include='*.js' --include='*.css' --include='*.html' \
+               'localhost:8080' internal/static/dist/ 2>/dev/null; then
+            echo "ERROR: 'localhost:8080' leaked into scaffolded production bundle"
+            exit 1
+          fi
+
+      - name: Smoke test — scaffolded binary serves SPA + API
+        working-directory: /tmp/test-go-react-spa
+        run: |
+          set -euo pipefail
+          PORT=18091 ./bin/server >/tmp/server.log 2>&1 &
+          server_pid=$!
+          trap "kill $server_pid 2>/dev/null || true" EXIT
+
+          for _ in $(seq 1 20); do
+            if curl -sSf -o /dev/null http://localhost:18091/api/v1/users; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          fail=0
+          check() {
+            local path="$1" expected="$2" label="$3"
+            local got
+            got=$(curl -sS -o /dev/null -w '%{http_code}' "http://localhost:18091${path}")
+            if [ "$got" = "$expected" ]; then
+              echo "OK  $label  GET $path -> $got"
+            else
+              echo "FAIL $label  GET $path -> $got (expected $expected)"
+              fail=1
+            fi
+          }
+          check "/"             200 "SPA index"
+          check "/api/v1/users" 200 "API"
+          check "/users"        200 "SPA fallback"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "--- server log ---"
+            cat /tmp/server.log || true
+            exit 1
+          fi
 
   scaffold-react:
     runs-on: ubuntu-latest

--- a/go-react-spa/README.md
+++ b/go-react-spa/README.md
@@ -1,0 +1,150 @@
+# Go React SPA Boilerplate
+
+Monolithic Go server with an embedded React SPA. The Go binary serves the
+SPA bundle and JSON API from a single port; in dev mode, Vite runs separately
+on `:5174` and proxies `/api` to Go on `:8080`.
+
+## Composite template
+
+This template is **composite**: it does not ship its own React source tree.
+Instead, the frontend is composed at build/dev time from:
+
+- `react-spa/` (sibling template) — the base SPA
+- `frontend.overlay/` — monolith-specific differences (`vite.config.ts`
+  proxy + `outDir`, empty `.env.production` so the bundle hardcodes
+  same-origin requests, `api/client.ts` `??` fallback)
+- `.compose.toml` — manifest that drives the merge
+
+`make compose` materializes both into `frontend/`. The materialized
+`frontend/` is **gitignored**; it is regenerated from base + overlay each
+time. When this template is scaffolded via `scripts/download.sh`, scaffold
+runs the same compose step against the extracted tarball and the
+**resulting project no longer needs the base template** — the scaffolded
+`frontend/` is self-contained and the `compose` machinery is stripped from
+its Makefile.
+
+## Project structure
+
+```
+go-react-spa/
+├── .compose.toml         # composite manifest (base + overlay)
+├── cmd/server/main.go    # binary entrypoint
+├── internal/
+│   ├── handler/          # HTTP + JSON API
+│   └── static/
+│       ├── static.go         # FileSystem interface
+│       ├── static_embed.go   # //go:build !dev — embeds dist/
+│       ├── static_dev.go     # //go:build dev   — empty stub
+│       └── dist/             # vite build output (embedded into binary)
+├── frontend.overlay/     # monolith-only diffs over react-spa
+├── frontend/             # composed at build time (gitignored)
+├── go.mod
+└── Makefile
+```
+
+## Build tags
+
+The static asset path is selected at build time:
+
+| Tag        | File                | Behavior                                              |
+|------------|---------------------|-------------------------------------------------------|
+| (default)  | `static_embed.go`   | `embed.FS` reads `internal/static/dist/` into binary  |
+| `-tags dev`| `static_dev.go`     | empty FS — Vite serves the SPA on `:5174`             |
+
+`make dev` runs `air` with `-tags dev` so the embedded bundle is bypassed
+and Vite is the source of truth for SPA assets. `make build` uses the
+default tag set so the bundle is embedded into the produced binary.
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js (matches `react-spa/.node-version`)
+- [air](https://github.com/cosmtrek/air) (only for `make dev`)
+- [golangci-lint](https://golangci-lint.run/) v2.11+
+
+## Quick start
+
+```bash
+# Install: composes frontend/ from base+overlay, then `go mod download` + `npm ci`
+make install
+
+# Build: `vite build` -> internal/static/dist/, then `go build` embedding the bundle
+make build
+
+# Run the binary (single port, serves SPA + API)
+./bin/server
+# open http://localhost:8080
+```
+
+## Development
+
+```bash
+# Two-process dev: Go (:8080) with hot reload + Vite (:5174) in parallel.
+# Vite proxies /api -> :8080, so open http://localhost:5174
+make dev
+
+# Stop both
+make stop
+```
+
+## Available commands
+
+```bash
+make install         # compose + download Go modules + npm ci
+make compose         # materialize frontend/ from base + overlay
+make compose-clean   # remove frontend/
+make build-frontend  # vite build -> internal/static/dist/
+make build           # build-frontend + go build (monolithic binary)
+make run             # run the built binary
+make dev             # Go (air, -tags dev) + Vite in parallel
+make stop            # kill dev servers on :8080 and :5174
+make status          # report which dev servers are running
+make lint            # golangci-lint
+make lint-frontend   # frontend ESLint
+make test            # go test
+make test-frontend   # frontend tests
+make test-cov        # go test with coverage
+make coverage        # frontend tests with coverage
+make check           # all linters + tests
+make ci              # CI: lint + test-cov + frontend lint + frontend test
+make verify          # smoke-test the scaffold pathway in a tmp dir
+make clean           # remove bin/, coverage.out, frontend/node_modules, dist/*
+```
+
+## Configuration
+
+| Variable | Default | Description                |
+|----------|---------|----------------------------|
+| PORT     | 8080    | Go server port             |
+
+## Routes
+
+| Method | Path                  | Description                          |
+|--------|-----------------------|--------------------------------------|
+| GET    | /health               | Health check                         |
+| GET    | /api/v1/users         | List users                           |
+| POST   | /api/v1/users         | Create user                          |
+| GET    | /api/v1/users/{id}    | Get user                             |
+| PUT    | /api/v1/users/{id}    | Update user                          |
+| DELETE | /api/v1/users/{id}    | Delete user                          |
+| GET    | /{anything-else}      | SPA fallback (embedded `dist/`, served via NotFound for client-side routing) |
+
+## Scaffolding
+
+Use the boilerplate-wide download script to scaffold a standalone project:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-react-spa ~/projects/my-app
+```
+
+The scaffold step composes `frontend/` from the base template + overlay,
+rewrites the Go module path and `package.json` `name`, strips the compose
+machinery from the Makefile, and produces a self-contained directory where
+`make install && make build && ./bin/server` works immediately.
+
+If the project will be published, after scaffolding run:
+
+```bash
+go mod edit -module github.com/<user>/<repo>
+```


### PR DESCRIPTION
## Summary

Issue #115 の残作業（PR #117 の go-react-spa CI 新設は完了済み）を片付ける PR。

- `scaffold-verify.yml` に **go-react-spa 専用 job** を追加し、download → install → build → 単一バイナリで SPA + API がサーブされる E2E パスを CI で常時検証
- `go-react-spa/README.md` を新設し、コンポジット構成（base + overlay）、build タグ運用、make ターゲット一覧、scaffold 手順を整理

## What / Why / How

**What:**
- `.github/workflows/scaffold-verify.yml`
  - `paths:` (push / pull_request) に `go-react-spa/**` 追加
  - 新 job `scaffold-go-react-spa`: setup-go (`go-react-spa/go.mod`) + setup-node (`react-spa/.node-version`) + golangci-lint インストール → `scaffold.sh template=go-react-spa` → `make install && make build` → 本番バンドルへの `localhost:8080` 漏れチェック → `./bin/server` 起動して `/`・`/api/v1/users`・`/users` (SPA fallback) を curl で 200 確認
- `go-react-spa/README.md` を新規追加
  - コンポジットの仕組み（`.compose.toml`、`frontend.overlay/`、`frontend/` は都度生成・gitignore）
  - build タグ意図 (`!dev` で `embed.FS` 有効、`dev` でスタブ)
  - `make dev` / `make build` / `make verify` の役割と挙動
  - 全 make ターゲット早見表
  - scaffold 経路（`download.sh ... go-react-spa <dest>`）の手順と公開時の `go mod edit` ガイダンス

**Why:**
- 他の Go テンプレートと違い go-react-spa はコンポジット構成 (`.compose.toml`) のため、scaffold は `react-spa/` を兄弟参照する必要があり、ビルドも `vite build → embed → go build` の二段で fragile。専用の scaffold-verify job を回さないと、ベース変更（`react-spa/**`）やオーバーレイ変更が無事にスキャフォールド経路を通るかが分からない
- README が無いとコンポジット構成（特に `frontend/` が gitignore されている点と build タグ運用）が他テンプレートと同じ感覚で読まれて混乱する

**How:**
- `paths:` に `go-react-spa/**` を追加することで、テンプレ本体の変更でもスキャフォールド検証が走る。`react-spa/**` は既に triggers に入っているのでベース変更でも発火する
- 新 job は `go-react-spa CI` (`go-react-spa.yml` / PR #117) と同じ smoke 手順をスキャフォールド後ディレクトリで再実行するため、source-tree 側と scaffold 経路の両輪をカバーする

## 確認方法

PR push 後 `Scaffold Verify` workflow がこのブランチで走り、`scaffold-go-react-spa` job が green になることを確認する。

```bash
gh pr checks <番号> --repo rengotaku/my-boilerplate
```

## Checklist

- [x] `make check` 相当（CI が担保）
- [x] CI ジョブ追加
- [x] README 追加

## 関連Issue

Refs #115
Depends on #117 (`scripts/scaffold` の compose 対応がマージされていないと scaffold-verify の go-react-spa job が落ちる)