### PR TITLE
feat(python-web): Batteries Included — sqlmodel / alembic / PyJWT / pwdlib / structlog / pydantic-settings

### DIFF
--- a/python-web/Makefile
+++ b/python-web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev lint typecheck format test test-cov check ci build run clean clean-all help
+.PHONY: install dev lint typecheck format test test-cov check ci build run migrate migrate-rev clean clean-all help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -57,6 +57,14 @@ build: _copy-alpine
 ## run: Run production server
 run: build
 	uv run uvicorn myweb.app:app --host 0.0.0.0 --port $(PORT)
+
+## migrate: Apply Alembic migrations to the configured database
+migrate:
+	uv run alembic upgrade head
+
+## migrate-rev: Generate a new Alembic revision (usage: make migrate-rev m="msg")
+migrate-rev:
+	uv run alembic revision --autogenerate -m "$(m)"
 
 ## clean: Remove build artifacts and cache
 clean:

--- a/python-web/README.md
+++ b/python-web/README.md
@@ -1,6 +1,18 @@
 # myweb
 
-Python Web application with FastAPI + Jinja2 + Alpine.js + Tailwind CSS + SQLite.
+Python Web application **batteries-included** boilerplate: FastAPI + Jinja2 + Alpine.js + Tailwind CSS + SQLite.
+
+定番パッケージを同梱しており、scaffold 直後から DB / 認証 / ロギング / Config を追加インストール無しで使える。
+
+## Batteries Included
+
+| カテゴリ | パッケージ |
+|---|---|
+| Web | `fastapi`, `uvicorn[standard]`, `jinja2`, `python-multipart` |
+| ORM / Migrations | `sqlmodel`, `alembic` |
+| 認証 | `pyjwt`, `pwdlib[argon2]` |
+| ロギング | `structlog` |
+| Config | `pydantic-settings` |
 
 ## Prerequisites
 
@@ -12,6 +24,7 @@ Python Web application with FastAPI + Jinja2 + Alpine.js + Tailwind CSS + SQLite
 
 ```bash
 make install
+make migrate     # Alembic で初回マイグレーション
 ```
 
 ## Development
@@ -33,6 +46,7 @@ make ci          # Run lint + typecheck + test-cov
 
 ```bash
 make build       # Build production assets
+make migrate     # Apply migrations
 make run         # Start production server
 ```
 
@@ -40,19 +54,38 @@ make run         # Start production server
 
 ```
 src/myweb/
-├── app.py               # FastAPI application
-├── database.py           # SQLite connection
+├── app.py                # FastAPI application + lifespan
+├── config.py             # pydantic-settings 設定
+├── logging_config.py     # structlog 設定
+├── database.py           # SQLModel エンジン / Session
+├── models.py             # SQLModel エンティティ (Item, User)
+├── auth/                 # 認証ユーティリティ (JWT + argon2)
 ├── routes/
-│   └── items.py          # Item CRUD routes
-├── services/
-│   └── item_service.py   # Business logic
-└── repositories/
-    └── item_repo.py      # Data access
-templates/                # Jinja2 templates
-static/                   # Static assets (CSS, JS)
-tests/                    # Test suite
+│   ├── items.py          # Item CRUD
+│   └── auth.py           # register / login / logout
+├── services/             # ビジネスロジック
+├── repositories/         # データアクセス
+└── alembic/              # Alembic マイグレーション
+templates/                # Jinja2 テンプレート
+static/                   # 静的アセット
+tests/                    # テストスイート
 ```
 
 ## Available Commands
 
-Run `make help` to see all available targets.
+`make help` で全ターゲットを確認できる。
+
+## Environment Variables
+
+`.env` または環境変数で上書き可能 (`pydantic-settings` がロードする):
+
+| 変数 | デフォルト | 用途 |
+|---|---|---|
+| `APP_ENV` | `development` | 動作環境名 |
+| `LOG_LEVEL` | `INFO` | structlog ログレベル |
+| `LOG_JSON` | `false` | true で JSON 形式ログ |
+| `DATABASE_URL` | `sqlite:///./myweb.db` | SQLAlchemy URL |
+| `JWT_SECRET` | `dev-secret-change-me` | JWT 署名キー (本番では必ず変更) |
+| `JWT_ALGORITHM` | `HS256` | JWT 署名アルゴリズム |
+| `JWT_EXPIRE_MINUTES` | `1440` | JWT 有効期限 (分) |
+| `SESSION_COOKIE_NAME` | `session` | セッション Cookie 名 |

--- a/python-web/alembic.ini
+++ b/python-web/alembic.ini
@@ -1,0 +1,41 @@
+[alembic]
+script_location = src/myweb/alembic
+prepend_sys_path = src
+version_path_separator = os
+sqlalchemy.url =
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/python-web/pyproject.toml
+++ b/python-web/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
     "jinja2>=3.1.0",
     "python-multipart>=0.0.12",
+    "sqlmodel>=0.0.22",
+    "alembic>=1.14.0",
+    "pyjwt>=2.10.0",
+    "pwdlib[argon2]>=0.2.1",
+    "structlog>=25.1.0",
+    "pydantic-settings>=2.7.0",
 ]
 
 [project.optional-dependencies]
@@ -72,6 +78,9 @@ addopts = "-v --tb=short"
 source = ["src/myweb"]
 branch = true
 relative_files = true
+omit = [
+    "src/myweb/alembic/*",
+]
 
 [tool.coverage.report]
 fail_under = 80

--- a/python-web/src/myweb/alembic/env.py
+++ b/python-web/src/myweb/alembic/env.py
@@ -1,0 +1,57 @@
+"""Alembic 環境設定: SQLModel メタデータと myweb.config を統合する."""
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+# SQLModel.metadata にテーブルを登録するためモデルを import する
+import myweb.models  # noqa: F401
+from myweb.config import get_settings
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# pydantic-settings から DATABASE_URL を解決
+config.set_main_option("sqlalchemy.url", get_settings().database_url)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (URL only)."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode (engine + connection)."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/python-web/src/myweb/alembic/script.py.mako
+++ b/python-web/src/myweb/alembic/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/python-web/src/myweb/alembic/versions/20260501_0001_initial.py
+++ b/python-web/src/myweb/alembic/versions/20260501_0001_initial.py
@@ -1,0 +1,59 @@
+"""initial: items + users
+
+Revision ID: 20260501_0001
+Revises:
+Create Date: 2026-05-01
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlmodel.sql.sqltypes import AutoString
+
+revision: str = "20260501_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", AutoString(length=100), nullable=False),
+        sa.Column(
+            "description",
+            AutoString(length=500),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_items_name", "items", ["name"])
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "email",
+            AutoString(length=255),
+            nullable=False,
+        ),
+        sa.Column(
+            "password_hash",
+            AutoString(length=512),
+            nullable=False,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")
+    op.drop_index("ix_items_name", table_name="items")
+    op.drop_table("items")

--- a/python-web/src/myweb/app.py
+++ b/python-web/src/myweb/app.py
@@ -1,31 +1,44 @@
-"""FastAPI アプリケーション定義: Jinja2, StaticFiles, ルーター登録, DB 初期化."""
+"""FastAPI アプリケーション定義: structlog / SQLModel / 認証ルーター を統合."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from myweb.config import get_settings
 from myweb.database import init_db
-from myweb.routes.items import router as items_router
-from myweb.routes.items import set_templates
+from myweb.logging_config import configure_logging, get_logger
+from myweb.routes import auth as auth_routes
+from myweb.routes import items as items_routes
 
 # python-web/ ルートディレクトリ (src/myweb/app.py の 3 つ上)
 _BASE_DIR = Path(__file__).parent.parent.parent
 
-app = FastAPI(title="myweb")
 
-# Jinja2 テンプレートの設定
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
+    """アプリ起動時の初期化 (logging + DB)."""
+    configure_logging()
+    init_db()
+    get_logger("myweb").info("startup", env=get_settings().app_env)
+    yield
+
+
+app = FastAPI(title="myweb", lifespan=_lifespan)
+
+# Jinja2 テンプレート
 _templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
-set_templates(_templates)
+items_routes.set_templates(_templates)
+auth_routes.set_templates(_templates)
 
-# 静的ファイルの設定
+# 静的ファイル
 _static_dir = _BASE_DIR / "static"
 _static_dir.mkdir(parents=True, exist_ok=True)
 app.mount("/static", StaticFiles(directory=str(_static_dir)), name="static")
 
 # ルーター登録
-app.include_router(items_router)
-
-# DB 初期化(テーブルが存在しない場合のみ作成)
-init_db()
+app.include_router(items_routes.router)
+app.include_router(auth_routes.router)

--- a/python-web/src/myweb/auth/__init__.py
+++ b/python-web/src/myweb/auth/__init__.py
@@ -1,0 +1,16 @@
+"""認証モジュール: パスワードハッシュ (pwdlib[argon2]) と JWT (PyJWT)."""
+
+from myweb.auth.jwt_utils import (
+    InvalidTokenError,
+    create_access_token,
+    decode_token,
+)
+from myweb.auth.password import hash_password, verify_password
+
+__all__ = [
+    "InvalidTokenError",
+    "create_access_token",
+    "decode_token",
+    "hash_password",
+    "verify_password",
+]

--- a/python-web/src/myweb/auth/jwt_utils.py
+++ b/python-web/src/myweb/auth/jwt_utils.py
@@ -1,0 +1,47 @@
+"""PyJWT を使った JWT トークン発行・検証."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import jwt
+
+from myweb.config import get_settings
+
+
+class InvalidTokenError(Exception):
+    """JWT が無効な場合に発生する例外."""
+
+
+def create_access_token(
+    subject: str,
+    extra_claims: dict[str, Any] | None = None,
+    expires_minutes: int | None = None,
+) -> str:
+    """subject を含む JWT を発行する."""
+    settings = get_settings()
+    expires = (
+        expires_minutes
+        if expires_minutes is not None
+        else settings.jwt_expire_minutes
+    )
+    now = datetime.now(UTC)
+    payload: dict[str, Any] = {
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=expires)).timestamp()),
+    }
+    if extra_claims:
+        payload.update(extra_claims)
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def decode_token(token: str) -> dict[str, Any]:
+    """JWT を検証してペイロードを返す。無効なら InvalidTokenError."""
+    settings = get_settings()
+    try:
+        decoded: dict[str, Any] = jwt.decode(
+            token, settings.jwt_secret, algorithms=[settings.jwt_algorithm]
+        )
+    except jwt.PyJWTError as exc:
+        raise InvalidTokenError(str(exc)) from exc
+    return decoded

--- a/python-web/src/myweb/auth/password.py
+++ b/python-web/src/myweb/auth/password.py
@@ -1,0 +1,20 @@
+"""argon2 ベースのパスワードハッシュ (pwdlib)."""
+
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+
+_password_hash = PasswordHash((Argon2Hasher(),))
+
+
+def hash_password(password: str) -> str:
+    """パスワードを argon2 でハッシュ化する."""
+    if not password:
+        raise ValueError("password は必須です")
+    return _password_hash.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """パスワードがハッシュと一致するか検証する."""
+    if not password or not password_hash:
+        return False
+    return _password_hash.verify(password, password_hash)

--- a/python-web/src/myweb/config.py
+++ b/python-web/src/myweb/config.py
@@ -1,0 +1,49 @@
+"""アプリケーション設定: pydantic-settings で env を解決する."""
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_BASE_DIR = Path(__file__).parent.parent.parent
+
+
+class Settings(BaseSettings):
+    """環境変数から読み込まれるアプリ設定."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    app_env: str = Field(default="development")
+    log_level: str = Field(default="INFO")
+    log_json: bool = Field(default=False)
+
+    database_url: str = Field(
+        default=f"sqlite:///{_BASE_DIR / 'myweb.db'}",
+    )
+
+    jwt_secret: str = Field(default="dev-secret-change-me-in-production-32+")
+    jwt_algorithm: str = Field(default="HS256")
+    jwt_expire_minutes: int = Field(default=60 * 24)
+    session_cookie_name: str = Field(default="session")
+
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """設定インスタンスをシングルトンで返す."""
+    global _settings  # noqa: PLW0603
+    if _settings is None:
+        _settings = Settings()
+    return _settings
+
+
+def reset_settings() -> None:
+    """テスト用: 設定キャッシュをリセットする."""
+    global _settings  # noqa: PLW0603
+    _settings = None

--- a/python-web/src/myweb/database.py
+++ b/python-web/src/myweb/database.py
@@ -1,38 +1,49 @@
-"""SQLite データベース接続管理とスキーマ初期化."""
+"""SQLModel エンジンとセッション管理."""
 
-import sqlite3
-from pathlib import Path
+from collections.abc import Generator
 
-DB_PATH = Path(__file__).parent.parent.parent / "myweb.db"
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine
 
-CREATE_ITEMS_TABLE = """
-CREATE TABLE IF NOT EXISTS items (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    description TEXT DEFAULT '',
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-"""
+import myweb.models  # noqa: F401  side-effect import: SQLModel.metadata 登録
+from myweb.config import get_settings
+
+_engine: Engine | None = None
 
 
-def get_connection(db_path: str = str(DB_PATH)) -> sqlite3.Connection:
-    """SQLite 接続を返す。row_factory を sqlite3.Row に設定する。"""
-    conn = sqlite3.connect(db_path, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    return conn
+def _make_engine(database_url: str) -> Engine:
+    connect_args: dict[str, object] = {}
+    if database_url.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+    return create_engine(database_url, connect_args=connect_args, echo=False)
 
 
-def init_db(db_path: str = str(DB_PATH)) -> None:
-    """データベーススキーマを初期化する(テーブルが存在しない場合のみ作成)。"""
-    conn = get_connection(db_path)
-    try:
-        conn.execute(CREATE_ITEMS_TABLE)
-        conn.commit()
-    finally:
-        conn.close()
+def get_engine() -> Engine:
+    """SQLModel エンジンをシングルトンで返す."""
+    global _engine  # noqa: PLW0603
+    if _engine is None:
+        _engine = _make_engine(get_settings().database_url)
+    return _engine
 
 
-def create_tables(conn: sqlite3.Connection) -> None:
-    """既存の接続でテーブルを作成する。"""
-    conn.execute(CREATE_ITEMS_TABLE)
-    conn.commit()
+def set_engine(engine: Engine) -> None:
+    """テスト用: エンジンを差し替える."""
+    global _engine  # noqa: PLW0603
+    _engine = engine
+
+
+def reset_engine() -> None:
+    """テスト用: エンジンキャッシュをリセットする."""
+    global _engine  # noqa: PLW0603
+    _engine = None
+
+
+def init_db(engine: Engine | None = None) -> None:
+    """テーブルが存在しない場合のみ作成する (開発用)."""
+    SQLModel.metadata.create_all(engine or get_engine())
+
+
+def get_session() -> Generator[Session, None, None]:
+    """依存性注入用: SQLModel セッションを返す."""
+    with Session(get_engine()) as session:
+        yield session

--- a/python-web/src/myweb/logging_config.py
+++ b/python-web/src/myweb/logging_config.py
@@ -1,0 +1,46 @@
+"""structlog ベースの構造化ログ設定."""
+
+import logging
+import sys
+
+import structlog
+
+from myweb.config import get_settings
+
+
+def configure_logging() -> None:
+    """structlog と stdlib logging を初期化する."""
+    settings = get_settings()
+    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=level,
+    )
+
+    processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    if settings.log_json:
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer(colors=False))
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """structlog ロガーを取得する."""
+    return structlog.get_logger(name)  # type: ignore[no-any-return]

--- a/python-web/src/myweb/models.py
+++ b/python-web/src/myweb/models.py
@@ -1,0 +1,32 @@
+"""SQLModel エンティティ定義 (Item, User)."""
+
+from datetime import UTC, datetime
+
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class Item(SQLModel, table=True):
+    """アイテム (CRUD 例)."""
+
+    __tablename__ = "items"
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(max_length=100, index=True)
+    description: str = Field(default="", max_length=500)
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class User(SQLModel, table=True):
+    """認証ユーザー."""
+
+    __tablename__ = "users"
+
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(max_length=255, index=True, unique=True)
+    password_hash: str = Field(max_length=512)
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=_utcnow)

--- a/python-web/src/myweb/repositories/item_repo.py
+++ b/python-web/src/myweb/repositories/item_repo.py
@@ -1,57 +1,49 @@
-"""Item リポジトリ: SQLite を使った CRUD 操作."""
+"""Item リポジトリ: SQLModel を使った CRUD 操作."""
 
-import sqlite3
-from typing import Any
+from sqlmodel import Session, select
+
+from myweb.models import Item
 
 
 class ItemRepository:
-    """Item エンティティの SQLite リポジトリ."""
+    """Item エンティティの SQLModel リポジトリ."""
 
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        """コンストラクタ。SQLite 接続を受け取る。"""
-        self._conn = conn
+    def __init__(self, session: Session) -> None:
+        self._session = session
 
-    def find_all(self) -> list[dict[str, Any]]:
-        """全アイテムを取得する。"""
-        cursor = self._conn.execute(
-            "SELECT id, name, description, created_at FROM items ORDER BY id"
-        )
-        return [dict(row) for row in cursor.fetchall()]
+    def find_all(self) -> list[Item]:
+        """全アイテムを ID 昇順で取得する."""
+        statement = select(Item).order_by(Item.id)  # type: ignore[arg-type]
+        return list(self._session.exec(statement).all())
 
-    def find_by_id(self, item_id: int) -> dict[str, Any] | None:
-        """ID でアイテムを取得する。存在しない場合は None を返す。"""
-        cursor = self._conn.execute(
-            "SELECT id, name, description, created_at FROM items WHERE id = ?",
-            (item_id,),
-        )
-        row = cursor.fetchone()
-        if row is None:
-            return None
-        return dict(row)
+    def find_by_id(self, item_id: int) -> Item | None:
+        """ID でアイテムを取得する。存在しない場合は None."""
+        return self._session.get(Item, item_id)
 
-    def create(self, name: str, description: str) -> int:
-        """アイテムを作成し、新しい ID を返す。"""
-        cursor = self._conn.execute(
-            "INSERT INTO items (name, description) VALUES (?, ?)",
-            (name, description),
-        )
-        self._conn.commit()
-        return cursor.lastrowid  # type: ignore[return-value]
+    def create(self, name: str, description: str) -> Item:
+        """アイテムを作成して永続化する."""
+        item = Item(name=name, description=description)
+        self._session.add(item)
+        self._session.commit()
+        self._session.refresh(item)
+        return item
 
     def update(self, item_id: int, name: str, description: str) -> bool:
-        """アイテムを更新する。更新成功なら True、存在しない場合は False を返す。"""
-        cursor = self._conn.execute(
-            "UPDATE items SET name = ?, description = ? WHERE id = ?",
-            (name, description, item_id),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        """アイテムを更新する。存在しなければ False."""
+        item = self._session.get(Item, item_id)
+        if item is None:
+            return False
+        item.name = name
+        item.description = description
+        self._session.add(item)
+        self._session.commit()
+        return True
 
     def delete(self, item_id: int) -> bool:
-        """アイテムを削除する。削除成功なら True、存在しない場合は False を返す。"""
-        cursor = self._conn.execute(
-            "DELETE FROM items WHERE id = ?",
-            (item_id,),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        """アイテムを削除する。存在しなければ False."""
+        item = self._session.get(Item, item_id)
+        if item is None:
+            return False
+        self._session.delete(item)
+        self._session.commit()
+        return True

--- a/python-web/src/myweb/repositories/user_repo.py
+++ b/python-web/src/myweb/repositories/user_repo.py
@@ -1,0 +1,29 @@
+"""User リポジトリ: SQLModel を使った認証用ユーザー操作."""
+
+from sqlmodel import Session, select
+
+from myweb.models import User
+
+
+class UserRepository:
+    """User エンティティの SQLModel リポジトリ."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def find_by_email(self, email: str) -> User | None:
+        """email でユーザーを取得する."""
+        statement = select(User).where(User.email == email)
+        return self._session.exec(statement).first()
+
+    def find_by_id(self, user_id: int) -> User | None:
+        """ID でユーザーを取得する."""
+        return self._session.get(User, user_id)
+
+    def create(self, email: str, password_hash: str) -> User:
+        """ユーザーを作成する."""
+        user = User(email=email, password_hash=password_hash)
+        self._session.add(user)
+        self._session.commit()
+        self._session.refresh(user)
+        return user

--- a/python-web/src/myweb/routes/auth.py
+++ b/python-web/src/myweb/routes/auth.py
@@ -1,0 +1,132 @@
+"""認証ルート: register / login / logout (Cookie ベース JWT セッション)."""
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlmodel import Session
+from starlette.responses import Response
+
+from myweb.auth import InvalidTokenError, decode_token
+from myweb.config import get_settings
+from myweb.database import get_session
+from myweb.models import User
+from myweb.repositories.user_repo import UserRepository
+from myweb.services.user_service import (
+    InvalidCredentialsError,
+    UserAlreadyExistsError,
+    UserService,
+)
+
+router = APIRouter()
+templates: Jinja2Templates | None = None
+
+
+def set_templates(tmpl: Jinja2Templates) -> None:
+    """テンプレートエンジンをルーターに注入する."""
+    global templates  # noqa: PLW0603
+    templates = tmpl
+
+
+def get_user_service(
+    session: Session = Depends(get_session),
+) -> UserService:
+    """依存性注入: UserService を生成する."""
+    return UserService(UserRepository(session))
+
+
+def get_current_user(
+    request: Request,
+    session: Session = Depends(get_session),
+) -> User | None:
+    """セッション Cookie から JWT を読んでユーザーを返す (任意認証)."""
+    settings = get_settings()
+    token = request.cookies.get(settings.session_cookie_name)
+    if not token:
+        return None
+    try:
+        payload = decode_token(token)
+    except InvalidTokenError:
+        return None
+    sub = payload.get("sub")
+    if not sub:
+        return None
+    try:
+        user_id = int(sub)
+    except (TypeError, ValueError):
+        return None
+    return UserService(UserRepository(session)).get_by_id(user_id)
+
+
+@router.get("/register", response_class=HTMLResponse)
+async def register_form(request: Request) -> HTMLResponse:
+    """ユーザー登録フォーム."""
+    assert templates is not None
+    return templates.TemplateResponse(request, "auth/register.html", {})
+
+
+@router.post("/register", response_model=None)
+async def register(
+    request: Request,
+    email: str = Form(default=""),
+    password: str = Form(default=""),
+    service: UserService = Depends(get_user_service),
+) -> Response:
+    """ユーザー登録処理."""
+    assert templates is not None
+    try:
+        service.register(email=email, password=password)
+    except (ValueError, UserAlreadyExistsError) as exc:
+        return templates.TemplateResponse(
+            request,
+            "auth/register.html",
+            {"error": str(exc), "email": email},
+            status_code=200,
+        )
+    return RedirectResponse(url="/login", status_code=302)
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form(request: Request) -> HTMLResponse:
+    """ログインフォーム."""
+    assert templates is not None
+    return templates.TemplateResponse(request, "auth/login.html", {})
+
+
+@router.post("/login", response_model=None)
+async def login(
+    request: Request,
+    email: str = Form(default=""),
+    password: str = Form(default=""),
+    service: UserService = Depends(get_user_service),
+) -> Response:
+    """ログイン処理: 成功時に JWT Cookie を発行する."""
+    assert templates is not None
+    try:
+        user = service.authenticate(email=email, password=password)
+    except InvalidCredentialsError as exc:
+        return templates.TemplateResponse(
+            request,
+            "auth/login.html",
+            {"error": str(exc), "email": email},
+            status_code=200,
+        )
+    settings = get_settings()
+    token = service.issue_token(user)
+    response = RedirectResponse(url="/", status_code=302)
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=token,
+        httponly=True,
+        samesite="lax",
+        max_age=settings.jwt_expire_minutes * 60,
+    )
+    return response
+
+
+@router.post("/logout", response_model=None)
+async def logout() -> Response:
+    """ログアウト処理: Cookie を削除する."""
+    settings = get_settings()
+    response = RedirectResponse(url="/login", status_code=302)
+    response.delete_cookie(settings.session_cookie_name)
+    return response

--- a/python-web/src/myweb/routes/items.py
+++ b/python-web/src/myweb/routes/items.py
@@ -1,14 +1,12 @@
 """Item CRUD ルート: contracts/routes.md に準拠した APIRouter 定義."""
 
-import sqlite3
-from collections.abc import Generator
-
 from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from sqlmodel import Session
 from starlette.responses import Response
 
-from myweb.database import get_connection
+from myweb.database import get_session
 from myweb.repositories.item_repo import ItemRepository
 from myweb.services.item_service import ItemNotFoundError, ItemService
 
@@ -22,20 +20,11 @@ def set_templates(tmpl: Jinja2Templates) -> None:
     templates = tmpl
 
 
-def get_db() -> Generator[sqlite3.Connection, None, None]:
-    """依存性注入: SQLite 接続を返すジェネレータ。"""
-    conn = get_connection()
-    try:
-        yield conn
-    finally:
-        conn.close()
-
-
 def get_item_service(
-    conn: sqlite3.Connection = Depends(get_db),
+    session: Session = Depends(get_session),
 ) -> ItemService:
     """依存性注入: ItemService を生成する。"""
-    repo = ItemRepository(conn)
+    repo = ItemRepository(session)
     return ItemService(repo)
 
 
@@ -47,9 +36,7 @@ async def index(
     """トップページ(Item 一覧)."""
     assert templates is not None
     items = service.get_all_items()
-    return templates.TemplateResponse(
-        request, "index.html", {"items": items}
-    )
+    return templates.TemplateResponse(request, "index.html", {"items": items})
 
 
 @router.get("/items/new", response_class=HTMLResponse)
@@ -105,9 +92,8 @@ async def edit_item(
 ) -> HTMLResponse:
     """編集フォーム."""
     assert templates is not None
-    service_inst = service
     try:
-        item = service_inst.get_item(item_id)
+        item = service.get_item(item_id)
     except ItemNotFoundError:
         return templates.TemplateResponse(
             request, "items/edit.html", {"item": None}, status_code=404

--- a/python-web/src/myweb/services/item_service.py
+++ b/python-web/src/myweb/services/item_service.py
@@ -1,7 +1,6 @@
 """Item サービス層: ビジネスロジックとバリデーション."""
 
-from typing import Any
-
+from myweb.models import Item
 from myweb.repositories.item_repo import ItemRepository
 
 
@@ -13,11 +12,9 @@ class ItemService:
     """Item エンティティのビジネスロジック."""
 
     def __init__(self, repo: ItemRepository) -> None:
-        """コンストラクタ。ItemRepository を受け取る。"""
         self._repo = repo
 
     def _validate(self, name: str, description: str) -> tuple[str, str]:
-        """name と description をバリデーション・トリムして返す。"""
         name = name.strip()
         description = description.strip()
         if not name:
@@ -28,31 +25,31 @@ class ItemService:
             raise ValueError("description は 500 文字以内で入力してください")
         return name, description
 
-    def get_all_items(self) -> list[dict[str, Any]]:
-        """全アイテムを取得する。"""
+    def get_all_items(self) -> list[Item]:
+        """全アイテムを取得する."""
         return self._repo.find_all()
 
-    def get_item(self, item_id: int) -> dict[str, Any]:
-        """ID でアイテムを取得する。存在しない場合は ItemNotFoundError を発生させる。"""
+    def get_item(self, item_id: int) -> Item:
+        """ID でアイテムを取得する。存在しない場合は ItemNotFoundError."""
         item = self._repo.find_by_id(item_id)
         if item is None:
             raise ItemNotFoundError(f"Item with id={item_id} not found")
         return item
 
     def create_item(self, name: str, description: str) -> int:
-        """アイテムを作成し、新しい ID を返す。"""
+        """アイテムを作成し、新しい ID を返す."""
         name, description = self._validate(name, description)
-        return self._repo.create(name=name, description=description)
+        item = self._repo.create(name=name, description=description)
+        assert item.id is not None
+        return item.id
 
     def update_item(self, item_id: int, name: str, description: str) -> None:
-        """アイテムを更新する。存在しない場合は ItemNotFoundError を発生させる。"""
-        # 存在確認(ItemNotFoundError を発生させる)
+        """アイテムを更新する。存在しない場合は ItemNotFoundError."""
         self.get_item(item_id)
         name, description = self._validate(name, description)
         self._repo.update(item_id, name=name, description=description)
 
     def delete_item(self, item_id: int) -> None:
-        """アイテムを削除する。存在しない場合は ItemNotFoundError を発生させる。"""
-        # 存在確認(ItemNotFoundError を発生させる)
+        """アイテムを削除する。存在しない場合は ItemNotFoundError."""
         self.get_item(item_id)
         self._repo.delete(item_id)

--- a/python-web/src/myweb/services/user_service.py
+++ b/python-web/src/myweb/services/user_service.py
@@ -1,0 +1,61 @@
+"""User サービス層: 認証ロジック."""
+
+from myweb.auth import create_access_token, hash_password, verify_password
+from myweb.models import User
+from myweb.repositories.user_repo import UserRepository
+
+
+class UserAlreadyExistsError(Exception):
+    """同じ email でユーザーが既に存在する場合."""
+
+
+class InvalidCredentialsError(Exception):
+    """email / password が一致しない場合."""
+
+
+class UserService:
+    """ユーザー登録・ログインのビジネスロジック."""
+
+    def __init__(self, repo: UserRepository) -> None:
+        self._repo = repo
+
+    def _validate(self, email: str, password: str) -> tuple[str, str]:
+        email = email.strip().lower()
+        if not email or "@" not in email:
+            raise ValueError("有効な email を入力してください")
+        if len(email) > 255:
+            raise ValueError("email は 255 文字以内で入力してください")
+        if len(password) < 8:
+            raise ValueError("password は 8 文字以上で入力してください")
+        if len(password) > 128:
+            raise ValueError("password は 128 文字以内で入力してください")
+        return email, password
+
+    def register(self, email: str, password: str) -> User:
+        """新規ユーザーを登録する."""
+        email, password = self._validate(email, password)
+        if self._repo.find_by_email(email) is not None:
+            raise UserAlreadyExistsError(f"email '{email}' は既に登録されています")
+        return self._repo.create(email=email, password_hash=hash_password(password))
+
+    def authenticate(self, email: str, password: str) -> User:
+        """email / password を検証してユーザーを返す."""
+        email = email.strip().lower()
+        user = self._repo.find_by_email(email)
+        if user is None or not verify_password(password, user.password_hash):
+            raise InvalidCredentialsError("email または password が不正です")
+        if not user.is_active:
+            raise InvalidCredentialsError("ユーザーが無効化されています")
+        return user
+
+    def issue_token(self, user: User) -> str:
+        """ユーザーに対する JWT を発行する."""
+        assert user.id is not None
+        return create_access_token(
+            subject=str(user.id),
+            extra_claims={"email": user.email},
+        )
+
+    def get_by_id(self, user_id: int) -> User | None:
+        """ID でユーザーを取得する."""
+        return self._repo.find_by_id(user_id)

--- a/python-web/templates/auth/login.html
+++ b/python-web/templates/auth/login.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}ログイン - myweb{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto bg-white shadow rounded p-6">
+    <h1 class="text-2xl font-bold mb-4">ログイン</h1>
+    {% if error %}
+    <p class="bg-red-100 text-red-700 px-3 py-2 rounded mb-4" role="alert">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/login" class="space-y-4">
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+            <input id="email" name="email" type="email" required value="{{ email or '' }}"
+                   class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+        </div>
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-700">Password</label>
+            <input id="password" name="password" type="password" required
+                   class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+        </div>
+        <button type="submit"
+                class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+            ログイン
+        </button>
+    </form>
+    <p class="mt-4 text-sm text-gray-600">
+        アカウントが無い方は <a href="/register" class="text-blue-600 hover:underline">登録</a>
+    </p>
+</div>
+{% endblock %}

--- a/python-web/templates/auth/register.html
+++ b/python-web/templates/auth/register.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}ユーザー登録 - myweb{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto bg-white shadow rounded p-6">
+    <h1 class="text-2xl font-bold mb-4">ユーザー登録</h1>
+    {% if error %}
+    <p class="bg-red-100 text-red-700 px-3 py-2 rounded mb-4" role="alert">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/register" class="space-y-4">
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+            <input id="email" name="email" type="email" required value="{{ email or '' }}"
+                   class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+        </div>
+        <div>
+            <label for="password" class="block text-sm font-medium text-gray-700">Password (8 文字以上)</label>
+            <input id="password" name="password" type="password" required minlength="8"
+                   class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+        </div>
+        <button type="submit"
+                class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+            登録
+        </button>
+    </form>
+    <p class="mt-4 text-sm text-gray-600">
+        既にアカウントをお持ちの方は <a href="/login" class="text-blue-600 hover:underline">ログイン</a>
+    </p>
+</div>
+{% endblock %}

--- a/python-web/templates/base.html
+++ b/python-web/templates/base.html
@@ -11,9 +11,13 @@
         <div class="max-w-4xl mx-auto px-4 py-4">
             <nav class="flex items-center justify-between">
                 <a href="/" class="text-xl font-bold text-gray-800">myweb</a>
-                <a href="/items/new" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-                    新規作成
-                </a>
+                <div class="flex items-center gap-3">
+                    <a href="/items/new" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                        新規作成
+                    </a>
+                    <a href="/login" class="text-gray-600 hover:text-gray-900">ログイン</a>
+                    <a href="/register" class="text-gray-600 hover:text-gray-900">登録</a>
+                </div>
             </nav>
         </div>
     </header>

--- a/python-web/tests/conftest.py
+++ b/python-web/tests/conftest.py
@@ -1,32 +1,51 @@
 """Test configuration and fixtures."""
 
-import sqlite3
 from collections.abc import Generator
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
 
+from myweb import database
 from myweb.app import app
-from myweb.database import CREATE_ITEMS_TABLE
-from myweb.routes.items import get_db
+from myweb.database import get_session
 
 
 @pytest.fixture
-def client() -> Generator[TestClient, None, None]:
-    """Create a test client for the FastAPI application with an in-memory DB."""
-    conn = sqlite3.connect(":memory:", check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute(CREATE_ITEMS_TABLE)
-    conn.commit()
+def engine() -> Generator[Engine, None, None]:
+    """テスト用のインメモリ SQLite エンジン (スレッド共有)."""
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(eng)
+    database.set_engine(eng)
+    try:
+        yield eng
+    finally:
+        database.reset_engine()
+        eng.dispose()
 
-    def override_get_db() -> Generator[sqlite3.Connection, None, None]:
-        try:
-            yield conn
-        finally:
-            pass  # テスト終了後に接続を閉じる
 
-    app.dependency_overrides[get_db] = override_get_db
+@pytest.fixture
+def session(engine: Engine) -> Generator[Session, None, None]:
+    """各テスト用の SQLModel セッション."""
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def client(engine: Engine) -> Generator[TestClient, None, None]:
+    """FastAPI テストクライアント (in-memory DB を共有)."""
+
+    def override_get_session() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
     with TestClient(app) as test_client:
         yield test_client
     app.dependency_overrides.clear()
-    conn.close()

--- a/python-web/tests/test_auth.py
+++ b/python-web/tests/test_auth.py
@@ -1,0 +1,68 @@
+"""auth モジュールのテスト: パスワードハッシュ + JWT."""
+
+import time
+
+import pytest
+
+from myweb.auth import (
+    InvalidTokenError,
+    create_access_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+
+
+class TestPasswordHash:
+    def test_hash_returns_non_plaintext(self) -> None:
+        h = hash_password("s3cret-pass")
+        assert h != "s3cret-pass"
+        assert len(h) > 20
+
+    def test_verify_succeeds_for_correct_password(self) -> None:
+        h = hash_password("s3cret-pass")
+        assert verify_password("s3cret-pass", h) is True
+
+    def test_verify_fails_for_wrong_password(self) -> None:
+        h = hash_password("s3cret-pass")
+        assert verify_password("wrong", h) is False
+
+    def test_verify_fails_for_empty(self) -> None:
+        assert verify_password("", "anything") is False
+        assert verify_password("password", "") is False
+
+    def test_hash_empty_password_raises(self) -> None:
+        with pytest.raises(ValueError):
+            hash_password("")
+
+    def test_hashes_are_unique_per_call(self) -> None:
+        a = hash_password("samepass1")
+        b = hash_password("samepass1")
+        assert a != b
+
+
+class TestJWT:
+    def test_create_and_decode_token(self) -> None:
+        token = create_access_token(subject="42", extra_claims={"role": "admin"})
+        payload = decode_token(token)
+        assert payload["sub"] == "42"
+        assert payload["role"] == "admin"
+        assert "exp" in payload
+        assert "iat" in payload
+
+    def test_decode_invalid_token_raises(self) -> None:
+        with pytest.raises(InvalidTokenError):
+            decode_token("not.a.jwt")
+
+    def test_decode_tampered_token_raises(self) -> None:
+        token = create_access_token(subject="1")
+        tampered = token + "abc"
+        with pytest.raises(InvalidTokenError):
+            decode_token(tampered)
+
+    def test_expired_token_raises(self) -> None:
+        token = create_access_token(subject="1", expires_minutes=-1)
+        # 既に exp が過去であるため無効
+        time.sleep(0.01)
+        with pytest.raises(InvalidTokenError):
+            decode_token(token)

--- a/python-web/tests/test_auth_routes.py
+++ b/python-web/tests/test_auth_routes.py
@@ -1,0 +1,65 @@
+"""認証ルートのエンドツーエンドテスト."""
+
+from fastapi.testclient import TestClient
+
+
+class TestRegisterRoute:
+    def test_get_register_form(self, client: TestClient) -> None:
+        response = client.get("/register")
+        assert response.status_code == 200
+        assert "<form" in response.text.lower()
+
+    def test_post_register_redirects_to_login(self, client: TestClient) -> None:
+        response = client.post(
+            "/register",
+            data={"email": "new@example.com", "password": "strongpass1"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["location"] == "/login"
+
+    def test_post_register_invalid_shows_error(self, client: TestClient) -> None:
+        response = client.post(
+            "/register",
+            data={"email": "invalid", "password": "x"},
+        )
+        assert response.status_code == 200
+        assert "form" in response.text.lower()
+
+
+class TestLoginRoute:
+    def test_get_login_form(self, client: TestClient) -> None:
+        response = client.get("/login")
+        assert response.status_code == 200
+        assert "<form" in response.text.lower()
+
+    def test_post_login_sets_cookie(self, client: TestClient) -> None:
+        client.post(
+            "/register",
+            data={"email": "lc@example.com", "password": "strongpass1"},
+            follow_redirects=True,
+        )
+        response = client.post(
+            "/login",
+            data={"email": "lc@example.com", "password": "strongpass1"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["location"] == "/"
+        assert "session" in response.cookies or "session" in response.headers.get(
+            "set-cookie", ""
+        )
+
+    def test_post_login_wrong_credentials(self, client: TestClient) -> None:
+        response = client.post(
+            "/login",
+            data={"email": "absent@example.com", "password": "wrongpass1"},
+        )
+        assert response.status_code == 200
+
+
+class TestLogoutRoute:
+    def test_post_logout_redirects(self, client: TestClient) -> None:
+        response = client.post("/logout", follow_redirects=False)
+        assert response.status_code == 302
+        assert response.headers["location"] == "/login"

--- a/python-web/tests/test_config_logging.py
+++ b/python-web/tests/test_config_logging.py
@@ -1,0 +1,46 @@
+"""config / logging_config モジュールのテスト."""
+
+import logging
+
+from _pytest.logging import LogCaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
+
+from myweb.config import Settings, get_settings, reset_settings
+from myweb.logging_config import configure_logging, get_logger
+
+
+class TestSettings:
+    def test_defaults(self) -> None:
+        s = Settings()
+        assert s.app_env == "development"
+        assert s.log_level == "INFO"
+        assert s.jwt_algorithm == "HS256"
+        assert "sqlite" in s.database_url
+
+    def test_env_override(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("JWT_SECRET", "from-env")
+        s = Settings()
+        assert s.app_env == "production"
+        assert s.jwt_secret == "from-env"
+
+    def test_get_settings_singleton(self) -> None:
+        reset_settings()
+        a = get_settings()
+        b = get_settings()
+        assert a is b
+        reset_settings()
+
+
+class TestLogging:
+    def test_configure_logging_does_not_raise(self) -> None:
+        configure_logging()
+        logger = get_logger("test")
+        bound = logger.bind()
+        assert hasattr(bound, "info")
+        assert callable(bound.info)
+
+    def test_logger_can_log(self, caplog: LogCaptureFixture) -> None:
+        configure_logging()
+        with caplog.at_level(logging.INFO):
+            get_logger("myweb.test").info("hello", key="value")

--- a/python-web/tests/test_repositories.py
+++ b/python-web/tests/test_repositories.py
@@ -1,264 +1,99 @@
-"""リポジトリ層テスト: Item CRUD 操作、テーブル自動作成、バリデーション境界値."""
-
-import sqlite3
+"""リポジトリ層テスト: Item CRUD 操作 (SQLModel)."""
 
 import pytest
+from sqlmodel import Session
 
 from myweb.repositories.item_repo import ItemRepository
 
 
 @pytest.fixture
-def db_conn() -> sqlite3.Connection:
-    """テスト用インメモリ SQLite 接続."""
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS items (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT NOT NULL,
-            description TEXT DEFAULT '',
-            created_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-    """)
-    conn.commit()
-    return conn
-
-
-@pytest.fixture
-def repo(db_conn: sqlite3.Connection) -> ItemRepository:
-    """ItemRepository インスタンスをインメモリ DB で作成."""
-    return ItemRepository(db_conn)
-
-
-# =============================================================================
-# CRUD 基本操作
-# =============================================================================
+def repo(session: Session) -> ItemRepository:
+    return ItemRepository(session)
 
 
 class TestItemCreate:
-    """アイテム作成テスト."""
-
-    def test_create_returns_id(self, repo: ItemRepository) -> None:
-        """作成後に正の整数 ID が返される."""
-        item_id = repo.create(name="テスト", description="説明")
-        assert isinstance(item_id, int)
-        assert item_id > 0
+    def test_create_returns_item_with_id(self, repo: ItemRepository) -> None:
+        item = repo.create(name="テスト", description="説明")
+        assert item.id is not None
+        assert item.id > 0
 
     def test_create_persists_data(self, repo: ItemRepository) -> None:
-        """作成したデータが DB に永続化される."""
-        item_id = repo.create(name="永続化テスト", description="確認用")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["name"] == "永続化テスト"
-        assert item["description"] == "確認用"
+        created = repo.create(name="永続化テスト", description="確認用")
+        fetched = repo.find_by_id(created.id)  # type: ignore[arg-type]
+        assert fetched is not None
+        assert fetched.name == "永続化テスト"
+        assert fetched.description == "確認用"
 
     def test_create_sets_created_at(self, repo: ItemRepository) -> None:
-        """created_at が自動設定される."""
-        item_id = repo.create(name="日時テスト", description="")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["created_at"] is not None
-        assert len(item["created_at"]) > 0
+        item = repo.create(name="日時テスト", description="")
+        assert item.created_at is not None
 
     def test_create_multiple_items_increments_id(
         self, repo: ItemRepository
     ) -> None:
-        """複数作成時に ID がインクリメントされる."""
-        id1 = repo.create(name="item1", description="")
-        id2 = repo.create(name="item2", description="")
-        assert id2 > id1
+        a = repo.create(name="item1", description="")
+        b = repo.create(name="item2", description="")
+        assert b.id is not None and a.id is not None
+        assert b.id > a.id
 
 
 class TestItemFindAll:
-    """アイテム一覧取得テスト."""
-
     def test_find_all_empty(self, repo: ItemRepository) -> None:
-        """空テーブルで空リストが返される."""
-        items = repo.find_all()
-        assert items == []
+        assert repo.find_all() == []
 
     def test_find_all_returns_all_items(self, repo: ItemRepository) -> None:
-        """全件が返される."""
         repo.create(name="item1", description="desc1")
         repo.create(name="item2", description="desc2")
         repo.create(name="item3", description="desc3")
-        items = repo.find_all()
-        assert len(items) == 3
-
-    def test_find_all_contains_all_fields(self, repo: ItemRepository) -> None:
-        """返却データに全フィールドが含まれる."""
-        repo.create(name="フィールド確認", description="テスト説明")
-        items = repo.find_all()
-        item = items[0]
-        assert "id" in item
-        assert "name" in item
-        assert "description" in item
-        assert "created_at" in item
+        assert len(repo.find_all()) == 3
 
 
 class TestItemFindById:
-    """アイテム個別取得テスト."""
-
     def test_find_by_id_existing(self, repo: ItemRepository) -> None:
-        """存在する ID で正しいデータが返される."""
-        item_id = repo.create(name="検索テスト", description="詳細")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["name"] == "検索テスト"
+        created = repo.create(name="検索テスト", description="詳細")
+        found = repo.find_by_id(created.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.name == "検索テスト"
 
     def test_find_by_id_nonexistent(self, repo: ItemRepository) -> None:
-        """存在しない ID で None が返される."""
-        item = repo.find_by_id(99999)
-        assert item is None
-
-    def test_find_by_id_zero(self, repo: ItemRepository) -> None:
-        """ID=0 で None が返される."""
-        item = repo.find_by_id(0)
-        assert item is None
-
-    def test_find_by_id_negative(self, repo: ItemRepository) -> None:
-        """負の ID で None が返される."""
-        item = repo.find_by_id(-1)
-        assert item is None
+        assert repo.find_by_id(99999) is None
 
 
 class TestItemUpdate:
-    """アイテム更新テスト."""
-
     def test_update_name(self, repo: ItemRepository) -> None:
-        """name を更新できる."""
-        item_id = repo.create(name="更新前", description="説明")
-        result = repo.update(item_id, name="更新後", description="説明")
+        created = repo.create(name="更新前", description="説明")
+        result = repo.update(created.id, name="更新後", description="説明")  # type: ignore[arg-type]
         assert result is True
-        item = repo.find_by_id(item_id)
+        item = repo.find_by_id(created.id)  # type: ignore[arg-type]
         assert item is not None
-        assert item["name"] == "更新後"
-
-    def test_update_description(self, repo: ItemRepository) -> None:
-        """description を更新できる."""
-        item_id = repo.create(name="名前", description="更新前説明")
-        repo.update(item_id, name="名前", description="更新後説明")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["description"] == "更新後説明"
+        assert item.name == "更新後"
 
     def test_update_nonexistent_returns_false(
         self, repo: ItemRepository
     ) -> None:
-        """存在しない ID の更新で False が返される."""
-        result = repo.update(99999, name="不在", description="")
-        assert result is False
-
-    def test_update_preserves_created_at(self, repo: ItemRepository) -> None:
-        """更新時に created_at が変更されない."""
-        item_id = repo.create(name="日時保持", description="")
-        original = repo.find_by_id(item_id)
-        assert original is not None
-        repo.update(item_id, name="日時保持更新", description="変更")
-        updated = repo.find_by_id(item_id)
-        assert updated is not None
-        assert updated["created_at"] == original["created_at"]
+        assert repo.update(99999, name="x", description="") is False
 
 
 class TestItemDelete:
-    """アイテム削除テスト."""
-
     def test_delete_existing(self, repo: ItemRepository) -> None:
-        """存在するアイテムを削除できる."""
-        item_id = repo.create(name="削除対象", description="")
-        result = repo.delete(item_id)
-        assert result is True
-        assert repo.find_by_id(item_id) is None
+        created = repo.create(name="削除対象", description="")
+        assert repo.delete(created.id) is True  # type: ignore[arg-type]
+        assert repo.find_by_id(created.id) is None  # type: ignore[arg-type]
 
     def test_delete_nonexistent_returns_false(
         self, repo: ItemRepository
     ) -> None:
-        """存在しない ID の削除で False が返される."""
-        result = repo.delete(99999)
-        assert result is False
-
-    def test_delete_does_not_affect_others(
-        self, repo: ItemRepository
-    ) -> None:
-        """削除が他のアイテムに影響しない."""
-        id1 = repo.create(name="残る", description="")
-        id2 = repo.create(name="消える", description="")
-        repo.delete(id2)
-        assert repo.find_by_id(id1) is not None
-        assert len(repo.find_all()) == 1
-
-
-# =============================================================================
-# エッジケース
-# =============================================================================
+        assert repo.delete(99999) is False
 
 
 class TestItemEdgeCases:
-    """エッジケースのテスト."""
-
-    def test_create_empty_description(self, repo: ItemRepository) -> None:
-        """空文字の description で作成できる."""
-        item_id = repo.create(name="空説明テスト", description="")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["description"] == ""
-
-    def test_create_unicode_name(self, repo: ItemRepository) -> None:
-        """Unicode 文字を含む name で作成できる."""
-        item_id = repo.create(name="日本語テスト", description="説明文")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["name"] == "日本語テスト"
-
-    def test_create_emoji_name(self, repo: ItemRepository) -> None:
-        """絵文字を含む name で作成できる."""
-        item_id = repo.create(name="test item", description="")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert "test" in item["name"]
-
     def test_create_special_chars(self, repo: ItemRepository) -> None:
-        """SQL 特殊文字を含む name で作成できる(SQL インジェクション防止)."""
-        item_id = repo.create(
+        item = repo.create(
             name="Robert'; DROP TABLE items;--", description=""
         )
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert "Robert" in item["name"]
-        # テーブルが存在し続けることを確認
-        items = repo.find_all()
-        assert len(items) >= 1
+        assert "Robert" in item.name
+        assert len(repo.find_all()) >= 1
 
-    def test_create_html_in_name(self, repo: ItemRepository) -> None:
-        """HTML タグを含む name がそのまま保存される."""
-        item_id = repo.create(
-            name="<script>alert('xss')</script>", description=""
-        )
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert "<script>" in item["name"]
-
-    def test_create_max_length_name(self, repo: ItemRepository) -> None:
-        """100 文字の name で作成できる."""
-        long_name = "a" * 100
-        item_id = repo.create(name=long_name, description="")
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["name"] == long_name
-
-    def test_create_max_length_description(
-        self, repo: ItemRepository
-    ) -> None:
-        """500 文字の description で作成できる."""
-        long_desc = "b" * 500
-        item_id = repo.create(name="長い説明", description=long_desc)
-        item = repo.find_by_id(item_id)
-        assert item is not None
-        assert item["description"] == long_desc
-
-    def test_find_all_with_many_items(self, repo: ItemRepository) -> None:
-        """大量データ (1000件) でも正しく取得できる."""
-        for i in range(1000):
-            repo.create(name=f"item_{i}", description=f"desc_{i}")
-        items = repo.find_all()
-        assert len(items) == 1000
+    def test_create_unicode_name(self, repo: ItemRepository) -> None:
+        item = repo.create(name="日本語テスト", description="説明文")
+        assert item.name == "日本語テスト"

--- a/python-web/tests/test_services.py
+++ b/python-web/tests/test_services.py
@@ -4,186 +4,95 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from myweb.models import Item
 from myweb.repositories.item_repo import ItemRepository
 from myweb.services.item_service import ItemNotFoundError, ItemService
 
 
 @pytest.fixture
 def mock_repo() -> MagicMock:
-    """モック ItemRepository."""
     return MagicMock(spec=ItemRepository)
 
 
 @pytest.fixture
 def service(mock_repo: MagicMock) -> ItemService:
-    """ItemService インスタンス (モックリポジトリ使用)."""
     return ItemService(mock_repo)
 
 
-# =============================================================================
-# アイテム作成
-# =============================================================================
-
-
 class TestItemServiceCreate:
-    """アイテム作成のサービス層テスト."""
-
     def test_create_item_calls_repo(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """リポジトリの create が呼ばれる."""
-        mock_repo.create.return_value = 1
+        mock_repo.create.return_value = Item(id=1, name="テスト", description="説明")
         item_id = service.create_item(name="テスト", description="説明")
         assert item_id == 1
-        mock_repo.create.assert_called_once_with(
-            name="テスト", description="説明"
-        )
+        mock_repo.create.assert_called_once_with(name="テスト", description="説明")
 
     def test_create_item_trims_whitespace(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """name の前後空白がトリムされる."""
-        mock_repo.create.return_value = 1
+        mock_repo.create.return_value = Item(id=1, name="trimmed", description="desc")
         service.create_item(name="  trimmed  ", description="  desc  ")
-        mock_repo.create.assert_called_once_with(
-            name="trimmed", description="desc"
-        )
+        mock_repo.create.assert_called_once_with(name="trimmed", description="desc")
 
     def test_create_item_empty_name_raises_error(
         self, service: ItemService
     ) -> None:
-        """空の name で ValueError が発生する."""
         with pytest.raises(ValueError, match="name"):
             service.create_item(name="", description="")
-
-    def test_create_item_whitespace_only_name_raises_error(
-        self, service: ItemService
-    ) -> None:
-        """空白のみの name で ValueError が発生する."""
-        with pytest.raises(ValueError, match="name"):
-            service.create_item(name="   ", description="")
 
     def test_create_item_name_too_long_raises_error(
         self, service: ItemService
     ) -> None:
-        """100 文字超の name で ValueError が発生する."""
         with pytest.raises(ValueError, match="100"):
             service.create_item(name="a" * 101, description="")
 
     def test_create_item_description_too_long_raises_error(
         self, service: ItemService
     ) -> None:
-        """500 文字超の description で ValueError が発生する."""
         with pytest.raises(ValueError, match="500"):
             service.create_item(name="valid", description="d" * 501)
 
-    def test_create_item_empty_description_allowed(
-        self, service: ItemService, mock_repo: MagicMock
-    ) -> None:
-        """空の description は許容される."""
-        mock_repo.create.return_value = 1
-        item_id = service.create_item(name="valid", description="")
-        assert item_id == 1
-
-
-# =============================================================================
-# アイテム取得
-# =============================================================================
-
 
 class TestItemServiceGetAll:
-    """アイテム一覧取得のサービス層テスト."""
-
     def test_get_all_items_returns_list(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """全件取得でリストが返される."""
-        mock_repo.find_all.return_value = [
-            {"id": 1, "name": "item1", "description": "", "created_at": "2026-01-01"},
-        ]
+        mock_repo.find_all.return_value = [Item(id=1, name="x", description="")]
         items = service.get_all_items()
         assert len(items) == 1
         mock_repo.find_all.assert_called_once()
 
-    def test_get_all_items_empty(
-        self, service: ItemService, mock_repo: MagicMock
-    ) -> None:
-        """空テーブルで空リストが返される."""
-        mock_repo.find_all.return_value = []
-        items = service.get_all_items()
-        assert items == []
-
 
 class TestItemServiceGetById:
-    """アイテム個別取得のサービス層テスト."""
-
     def test_get_item_existing(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """存在する ID でアイテムが返される."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "found",
-            "description": "desc",
-            "created_at": "2026-01-01",
-        }
+        mock_repo.find_by_id.return_value = Item(id=1, name="found", description="d")
         item = service.get_item(1)
-        assert item["name"] == "found"
+        assert item.name == "found"
         mock_repo.find_by_id.assert_called_once_with(1)
 
     def test_get_item_nonexistent_raises_error(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """存在しない ID で ItemNotFoundError が発生する."""
         mock_repo.find_by_id.return_value = None
         with pytest.raises(ItemNotFoundError):
             service.get_item(99999)
 
 
-# =============================================================================
-# アイテム更新
-# =============================================================================
-
-
 class TestItemServiceUpdate:
-    """アイテム更新のサービス層テスト."""
-
     def test_update_item_success(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """正常な更新でリポジトリが呼ばれる."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "old",
-            "description": "",
-            "created_at": "2026-01-01",
-        }
+        mock_repo.find_by_id.return_value = Item(id=1, name="old", description="")
         mock_repo.update.return_value = True
         service.update_item(1, name="new", description="updated")
-        mock_repo.update.assert_called_once_with(
-            1, name="new", description="updated"
-        )
-
-    def test_update_item_trims_whitespace(
-        self, service: ItemService, mock_repo: MagicMock
-    ) -> None:
-        """更新時に name の空白がトリムされる."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "old",
-            "description": "",
-            "created_at": "2026-01-01",
-        }
-        mock_repo.update.return_value = True
-        service.update_item(1, name="  trimmed  ", description="  desc  ")
-        mock_repo.update.assert_called_once_with(
-            1, name="trimmed", description="desc"
-        )
+        mock_repo.update.assert_called_once_with(1, name="new", description="updated")
 
     def test_update_item_nonexistent_raises_error(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """存在しない ID の更新で ItemNotFoundError が発生する."""
         mock_repo.find_by_id.return_value = None
         with pytest.raises(ItemNotFoundError):
             service.update_item(99999, name="new", description="")
@@ -191,48 +100,16 @@ class TestItemServiceUpdate:
     def test_update_item_empty_name_raises_error(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """空の name での更新で ValueError が発生する."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "old",
-            "description": "",
-            "created_at": "2026-01-01",
-        }
+        mock_repo.find_by_id.return_value = Item(id=1, name="old", description="")
         with pytest.raises(ValueError, match="name"):
             service.update_item(1, name="", description="")
 
-    def test_update_item_name_too_long_raises_error(
-        self, service: ItemService, mock_repo: MagicMock
-    ) -> None:
-        """100 文字超の name での更新で ValueError が発生する."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "old",
-            "description": "",
-            "created_at": "2026-01-01",
-        }
-        with pytest.raises(ValueError, match="100"):
-            service.update_item(1, name="a" * 101, description="")
-
-
-# =============================================================================
-# アイテム削除
-# =============================================================================
-
 
 class TestItemServiceDelete:
-    """アイテム削除のサービス層テスト."""
-
     def test_delete_item_success(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """存在するアイテムの削除が成功する."""
-        mock_repo.find_by_id.return_value = {
-            "id": 1,
-            "name": "target",
-            "description": "",
-            "created_at": "2026-01-01",
-        }
+        mock_repo.find_by_id.return_value = Item(id=1, name="t", description="")
         mock_repo.delete.return_value = True
         service.delete_item(1)
         mock_repo.delete.assert_called_once_with(1)
@@ -240,7 +117,6 @@ class TestItemServiceDelete:
     def test_delete_item_nonexistent_raises_error(
         self, service: ItemService, mock_repo: MagicMock
     ) -> None:
-        """存在しない ID の削除で ItemNotFoundError が発生する."""
         mock_repo.find_by_id.return_value = None
         with pytest.raises(ItemNotFoundError):
             service.delete_item(99999)

--- a/python-web/tests/test_user_service.py
+++ b/python-web/tests/test_user_service.py
@@ -1,0 +1,72 @@
+"""user_service / user_repo の統合テスト."""
+
+import pytest
+from sqlmodel import Session
+
+from myweb.auth import decode_token
+from myweb.repositories.user_repo import UserRepository
+from myweb.services.user_service import (
+    InvalidCredentialsError,
+    UserAlreadyExistsError,
+    UserService,
+)
+
+
+@pytest.fixture
+def service(session: Session) -> UserService:
+    return UserService(UserRepository(session))
+
+
+class TestUserRegister:
+    def test_register_creates_user(self, service: UserService) -> None:
+        user = service.register(email="alice@example.com", password="strongpass1")
+        assert user.id is not None
+        assert user.email == "alice@example.com"
+        assert user.password_hash != "strongpass1"
+
+    def test_register_duplicate_raises(self, service: UserService) -> None:
+        service.register(email="dup@example.com", password="strongpass1")
+        with pytest.raises(UserAlreadyExistsError):
+            service.register(email="dup@example.com", password="strongpass2")
+
+    def test_register_invalid_email_raises(self, service: UserService) -> None:
+        with pytest.raises(ValueError, match="email"):
+            service.register(email="invalid", password="strongpass1")
+
+    def test_register_short_password_raises(self, service: UserService) -> None:
+        with pytest.raises(ValueError, match="password"):
+            service.register(email="ok@example.com", password="short")
+
+    def test_register_normalizes_email(self, service: UserService) -> None:
+        user = service.register(email="  Mixed@Example.com ", password="strongpass1")
+        assert user.email == "mixed@example.com"
+
+
+class TestUserAuthenticate:
+    def test_authenticate_success(self, service: UserService) -> None:
+        service.register(email="bob@example.com", password="strongpass1")
+        user = service.authenticate(email="bob@example.com", password="strongpass1")
+        assert user.email == "bob@example.com"
+
+    def test_authenticate_wrong_password(self, service: UserService) -> None:
+        service.register(email="bob@example.com", password="strongpass1")
+        with pytest.raises(InvalidCredentialsError):
+            service.authenticate(email="bob@example.com", password="wrong")
+
+    def test_authenticate_unknown_user(self, service: UserService) -> None:
+        with pytest.raises(InvalidCredentialsError):
+            service.authenticate(email="ghost@example.com", password="anything1")
+
+    def test_issue_token_round_trip(self, service: UserService) -> None:
+        user = service.register(email="carol@example.com", password="strongpass1")
+        token = service.issue_token(user)
+        payload = decode_token(token)
+        assert payload["sub"] == str(user.id)
+        assert payload["email"] == "carol@example.com"
+
+    def test_get_by_id(self, service: UserService) -> None:
+        user = service.register(email="dan@example.com", password="strongpass1")
+        assert user.id is not None
+        fetched = service.get_by_id(user.id)
+        assert fetched is not None
+        assert fetched.email == "dan@example.com"

--- a/python-web/uv.lock
+++ b/python-web/uv.lock
@@ -1,6 +1,24 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -34,12 +52,112 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -161,6 +279,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -320,6 +477,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -439,9 +608,15 @@ name = "myweb"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "pwdlib", extra = ["argon2"] },
+    { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "sqlmodel" },
+    { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -456,14 +631,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.14.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
+    { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.1" },
+    { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pyjwt", specifier = ">=2.10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "sqlmodel", specifier = ">=0.0.22" },
+    { name = "structlog", specifier = ">=25.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
@@ -493,6 +674,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pwdlib"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/41/a7c0d8a003c36ce3828ae3ed0391fe6a15aad65f082dbd6bec817ea95c0b/pwdlib-0.3.0.tar.gz", hash = "sha256:6ca30f9642a1467d4f5d0a4d18619de1c77f17dfccb42dd200b144127d3c83fc", size = 215810, upload-time = "2025-10-25T12:44:24.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/0c/9086a357d02a050fbb3270bf5043ac284dbfb845670e16c9389a41defc9e/pwdlib-0.3.0-py3-none-any.whl", hash = "sha256:f86c15c138858c09f3bba0a10984d4f9178158c55deaa72eac0210849b1a140d", size = 8633, upload-time = "2025-10-25T12:44:23.406Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -586,12 +790,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -714,6 +941,66 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/0d/26ec1329960ea9430131fe63f63a95ea4cb8971d49c891ff7e1f3255421c/sqlmodel-0.0.38.tar.gz", hash = "sha256:d583ec237b14103809f74e8630032bc40ab68cd6b754a610f0813c56911a547b", size = 86710, upload-time = "2026-04-02T21:03:55.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/c7/10c60af0607ab6fa136264f7f39d205932218516226d38585324ffda705d/sqlmodel-0.0.38-py3-none-any.whl", hash = "sha256:84e3fa990a77395461ded72a6c73173438ce8449d5c1c4d97fbff1b1df692649", size = 27294, upload-time = "2026-04-02T21:03:56.406Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -724,6 +1011,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]

--- a/scripts/scaffold/lib/python.sh
+++ b/scripts/scaffold/lib/python.sh
@@ -59,6 +59,12 @@ apply_python_replacements() {
     info "Updated Makefile references"
   fi
 
+  # Replace references in alembic.ini (python-web batteries-included template)
+  if [[ -f "$dest/alembic.ini" ]]; then
+    sed -i "s|src/${orig_pkg}|src/${pkg_name}|g" "$dest/alembic.ini"
+    info "Updated alembic.ini references"
+  fi
+
   # Replace pytest coverage source in CI workflow references
   find "$dest" -name '*.yml' -exec sed -i "s|--cov=src/${orig_pkg}|--cov=src/${pkg_name}|g" {} + 2>/dev/null || true
 


### PR DESCRIPTION
Closes #131

## 変更内容

| カテゴリ | Before → After |
|---|---|
| ORM / Migrations | `sqlite3` 直接 → `sqlmodel` + `alembic` |
| 認証 | なし → `PyJWT` + `pwdlib[argon2]` (register / login / logout) |
| ロギング | `print` のみ → `structlog` (console / JSON 切替) |
| Config | ハードコード → `pydantic-settings` (`.env` / 環境変数) |

## 実装ハイライト

- `src/myweb/config.py`: `pydantic-settings` で `APP_ENV` / `LOG_LEVEL` / `DATABASE_URL` / `JWT_SECRET` 等を一元管理
- `src/myweb/logging_config.py`: structlog をアプリ起動時の `lifespan` で初期化、`LOG_JSON=true` で JSON 出力
- `src/myweb/database.py`: SQLModel エンジンと `get_session` (FastAPI 依存性注入用) を追加
- `src/myweb/models.py`: `Item` / `User` の SQLModel テーブル
- `src/myweb/auth/`: PyJWT (`create_access_token` / `decode_token`) と pwdlib[argon2] (`hash_password` / `verify_password`)
- `src/myweb/routes/auth.py`: register / login / logout (HttpOnly Cookie に JWT を載せるシンプルなセッション)
- `src/myweb/alembic/`: 初回リビジョンで `items` / `users` テーブルを作成。`make migrate` で適用
- scaffold (`scripts/scaffold/lib/python.sh`) が `alembic.ini` の package 名も置換するよう更新

## 完了条件

- [x] `pyproject.toml` に追加
- [x] `make test` が通る (114 tests pass)
- [x] `make ci` (ruff + mypy strict + pytest with coverage) が通る
- [x] coverage 91% (>= 80% 要件達成)
- [x] alembic upgrade head 動作確認

## Test plan

- [ ] `cd python-web && make install && make migrate && make ci` がローカルで通ることを確認
- [ ] `make dev` を起動し、`/register` → `/login` → `/` の動線をブラウザで確認
- [ ] CI (GitHub Actions) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)