### PR TITLE
[WIP] refactor: unify Makefile targets around `make run`

### DIFF
--- a/.github/workflows/scaffold-verify-react.yml
+++ b/.github/workflows/scaffold-verify-react.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: /tmp/test-${{ inputs.template }}
         run: |
           npm install
-          make lint format-check test-coverage build
+          make ci

--- a/go-graphql-api/Makefile
+++ b/go-graphql-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run dev stop status lint test test-cov check ci generate migrate migrate-diff migrate-apply migrate-hash clean help
+.PHONY: install build run run-bare stop status lint test test-cov check ci generate migrate migrate-diff migrate-apply migrate-hash clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -9,21 +9,22 @@ BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 8080
 
-## install: Download dependencies
+## install: Download dependencies and dev tools
 install:
 	go mod download
+	go install github.com/air-verse/air@latest
 
 ## build: Build the binary
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server
+## run: Run the server with hot reload (requires air; installed by `make install`)
 run:
-	go run ./cmd/server
-
-## dev: Run with hot reload (requires air: go install github.com/air-verse/air@latest)
-dev:
 	air
+
+## run-bare: Run the server without hot reload
+run-bare:
+	go run ./cmd/server
 
 ## stop: Stop the server
 stop:

--- a/go-graphql-api/README.md
+++ b/go-graphql-api/README.md
@@ -37,23 +37,23 @@ open http://localhost:8080/
 ## Development (Hot Reload)
 
 ```bash
-# Install Air (once)
-go install github.com/air-verse/air@latest
+# Install dependencies + air (once)
+make install
 
 # Run with hot reload
-make dev
+make run
 ```
 
-Air will watch `.go` files and automatically rebuild/restart the server on changes.
+Air watches `.go` files and automatically rebuilds/restarts the server on changes.
 
 ## Commands
 
 ```bash
 make help           # Show all commands
-make install        # Download dependencies
+make install        # Download dependencies and dev tools (air)
 make build          # Build the binary
-make run            # Run the server
-make dev            # Run with hot reload (requires air)
+make run            # Run the server with hot reload (air)
+make run-bare       # Run the server without hot reload
 make lint           # Run golangci-lint
 make test           # Run tests
 make test-cov       # Run tests with coverage

--- a/go-grpc-api/Makefile
+++ b/go-grpc-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run dev stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean generate help
+.PHONY: install build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean generate help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -9,9 +9,10 @@ BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 50051
 
-## install: Download dependencies
+## install: Download dependencies and dev tools
 install:
 	go mod download
+	go install github.com/air-verse/air@latest
 
 ## generate: Generate protobuf code using buf
 generate:
@@ -21,13 +22,13 @@ generate:
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server
+## run: Run the server with hot reload (requires air; installed by `make install`)
 run:
-	go run ./cmd/server
-
-## dev: Run with hot reload (requires air: go install github.com/air-verse/air@latest)
-dev:
 	air
+
+## run-bare: Run the server without hot reload
+run-bare:
+	go run ./cmd/server
 
 ## stop: Stop the server
 stop:

--- a/go-grpc-api/README.md
+++ b/go-grpc-api/README.md
@@ -74,23 +74,23 @@ make run
 ## Development (Hot Reload)
 
 ```bash
-# Install Air (once)
-go install github.com/air-verse/air@latest
+# Install dependencies + air (once)
+make install
 
 # Run with hot reload
-make dev
+make run
 ```
 
-Air will watch `.go` files and automatically rebuild/restart the server on changes.
+Air watches `.go` files and automatically rebuilds/restarts the server on changes.
 
 ## Available Commands
 
 ```bash
-make install        # Download dependencies
+make install        # Download dependencies and dev tools (air)
 make generate       # Generate protobuf code
 make build          # Build the binary
-make run            # Run the server
-make dev            # Run with hot reload (requires air)
+make run            # Run the server with hot reload (air)
+make run-bare       # Run the server without hot reload
 make lint           # Run golangci-lint
 make test           # Run tests
 make test-cov       # Run tests with coverage

--- a/go-react-spa/Makefile
+++ b/go-react-spa/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build build-frontend run dev dev-server dev-frontend stop status \
+.PHONY: install build build-frontend run run-binary run-server run-frontend stop status \
 	compose compose-clean verify \
 	lint lint-frontend lint-fix format format-check \
 	test test-frontend test-cov test-watch coverage \
@@ -58,21 +58,21 @@ build-frontend: compose
 build: build-frontend
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the built monolithic binary
-run:
-	./$(BIN_DIR)/$(BINARY_NAME)
+## run: Run Go (with hot reload via air, -tags dev) + Vite in parallel
+run: compose
+	$(MAKE) -j2 run-server run-frontend
 
-## dev: Run Go (with hot reload via air, -tags dev) + Vite in parallel
-dev: compose
-	$(MAKE) -j2 dev-server dev-frontend
-
-## dev-server: Run Go server with hot reload (uses -tags dev so embed is bypassed)
-dev-server:
+## run-server: Run Go server with hot reload (uses -tags dev so embed is bypassed)
+run-server:
 	air
 
-## dev-frontend: Run Vite dev server (proxies /api to Go)
-dev-frontend:
+## run-frontend: Run Vite dev server (proxies /api to Go)
+run-frontend:
 	cd $(FRONTEND_DIR) && npm run dev
+
+## run-binary: Run the built monolithic binary (no hot reload)
+run-binary:
+	./$(BIN_DIR)/$(BINARY_NAME)
 
 ## stop: Stop both Go and Vite dev servers
 stop:

--- a/go-react-spa/README.md
+++ b/go-react-spa/README.md
@@ -51,7 +51,7 @@ The static asset path is selected at build time:
 | (default)  | `static_embed.go`   | `embed.FS` reads `internal/static/dist/` into binary  |
 | `-tags dev`| `static_dev.go`     | empty FS — Vite serves the SPA on `:5174`             |
 
-`make dev` runs `air` with `-tags dev` so the embedded bundle is bypassed
+`make run` runs `air` with `-tags dev` so the embedded bundle is bypassed
 and Vite is the source of truth for SPA assets. `make build` uses the
 default tag set so the bundle is embedded into the produced binary.
 
@@ -59,7 +59,7 @@ default tag set so the bundle is embedded into the produced binary.
 
 - Go 1.25+
 - Node.js (matches `react-spa/.node-version`)
-- [air](https://github.com/cosmtrek/air) (only for `make dev`)
+- [air](https://github.com/cosmtrek/air) (only for `make run`)
 - [golangci-lint](https://golangci-lint.run/) v2.11+
 
 ## Quick start
@@ -71,8 +71,8 @@ make install
 # Build: `vite build` -> internal/static/dist/, then `go build` embedding the bundle
 make build
 
-# Run the binary (single port, serves SPA + API)
-./bin/server
+# Run the built binary (single port, serves SPA + API)
+make run-binary
 # open http://localhost:8080
 ```
 
@@ -81,7 +81,7 @@ make build
 ```bash
 # Two-process dev: Go (:8080) with hot reload + Vite (:5174) in parallel.
 # Vite proxies /api -> :8080, so open http://localhost:5174
-make dev
+make run
 
 # Stop both
 make stop
@@ -95,8 +95,8 @@ make compose         # materialize frontend/ from base + overlay
 make compose-clean   # remove frontend/
 make build-frontend  # vite build -> internal/static/dist/
 make build           # build-frontend + go build (monolithic binary)
-make run             # run the built binary
-make dev             # Go (air, -tags dev) + Vite in parallel
+make run             # Go (air, -tags dev) + Vite in parallel
+make run-binary      # run the built monolithic binary (no hot reload)
 make stop            # kill dev servers on :8080 and :5174
 make status          # report which dev servers are running
 make lint            # golangci-lint

--- a/go-rest-api/Makefile
+++ b/go-rest-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run dev stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean help
+.PHONY: install build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -18,13 +18,13 @@ install:
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server
+## run: Run the server with hot reload (requires air; installed by `make install`)
 run:
-	go run ./cmd/server
-
-## dev: Run with hot reload (requires air: go install github.com/air-verse/air@latest)
-dev:
 	air
+
+## run-bare: Run the server without hot reload
+run-bare:
+	go run ./cmd/server
 
 ## stop: Stop the server
 stop:

--- a/go-rest-api/README.md
+++ b/go-rest-api/README.md
@@ -47,19 +47,21 @@ curl http://localhost:10080/api/v1/users \
 
 ## Development (Hot Reload)
 
+`make install` installs `air` for hot reload, then `make run` starts the server with reload enabled.
+
 ```bash
-go install github.com/air-verse/air@latest
-make dev
+make install
+make run
 ```
 
 ## Commands
 
 ```bash
 make help            # Show all commands
-make install         # Download dependencies
+make install         # Download dependencies and dev tools (air)
 make build           # Build the binary
-make run             # Run the server
-make dev             # Run with hot reload
+make run             # Run the server with hot reload (air)
+make run-bare        # Run the server without hot reload
 make lint            # Run golangci-lint
 make test            # Run tests
 make test-cov        # Run tests with coverage

--- a/python-cli/Makefile
+++ b/python-cli/Makefile
@@ -1,5 +1,8 @@
 .PHONY: install lint typecheck format test test-cov check ci run clean clean-all help
 
+# Default target
+.DEFAULT_GOAL := help
+
 ## install: Install dependencies with uv
 install:
 	uv sync --all-extras
@@ -48,4 +51,7 @@ clean-all: clean
 
 ## help: Show this help
 help:
-	@grep -E '^##' Makefile | sed 's/## //'
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'

--- a/python-web/Makefile
+++ b/python-web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run run-prod lint typecheck format test test-cov check ci build migrate migrate-rev clean clean-all help
+.PHONY: install run lint typecheck format test test-cov check ci build migrate migrate-rev clean clean-all help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -53,10 +53,6 @@ ci: lint typecheck test-cov
 ## build: Build production assets (Tailwind CSS minify)
 build: _copy-alpine
 	npx @tailwindcss/cli -i static/css/input.css -o static/css/style.css --minify
-
-## run-prod: Run production server (no reload, builds assets first)
-run-prod: build
-	uv run uvicorn myweb.app:app --host 0.0.0.0 --port $(PORT)
 
 ## migrate: Apply Alembic migrations to the configured database
 migrate:

--- a/python-web/Makefile
+++ b/python-web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev lint typecheck format test test-cov check ci build run migrate migrate-rev clean clean-all help
+.PHONY: install run run-prod lint typecheck format test test-cov check ci build migrate migrate-rev clean clean-all help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -12,8 +12,8 @@ install:
 	uv sync --all-extras
 	npm install
 
-## dev: Start development server (uvicorn reload + Tailwind watch)
-dev: _build-assets
+## run: Start development server (uvicorn reload + Tailwind watch)
+run: _build-assets
 	@_port=$(PORT); \
 	if ! python3 -c "import socket; s=socket.socket(); s.bind(('',$$_port)); s.close()" 2>/dev/null; then \
 		_port=$$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"); \
@@ -54,8 +54,8 @@ ci: lint typecheck test-cov
 build: _copy-alpine
 	npx @tailwindcss/cli -i static/css/input.css -o static/css/style.css --minify
 
-## run: Run production server
-run: build
+## run-prod: Run production server (no reload, builds assets first)
+run-prod: build
 	uv run uvicorn myweb.app:app --host 0.0.0.0 --port $(PORT)
 
 ## migrate: Apply Alembic migrations to the configured database

--- a/python-web/README.md
+++ b/python-web/README.md
@@ -42,13 +42,14 @@ make test-cov    # Run tests with coverage
 make ci          # Run lint + typecheck + test-cov
 ```
 
-## Production
+## Production assets
 
 ```bash
-make build       # Build production assets
+make build       # Build production assets (Tailwind CSS minify)
 make migrate     # Apply migrations
-make run-prod    # Start production server (no reload)
 ```
+
+Makefile はローカル開発用。本番サーバー起動はホスト環境の手段 (uvicorn 直叩き / gunicorn / systemd / Docker など) で行う。
 
 ## Project Structure
 

--- a/python-web/README.md
+++ b/python-web/README.md
@@ -30,7 +30,7 @@ make migrate     # Alembic で初回マイグレーション
 ## Development
 
 ```bash
-make dev
+make run
 # Open http://localhost:8000
 ```
 
@@ -47,7 +47,7 @@ make ci          # Run lint + typecheck + test-cov
 ```bash
 make build       # Build production assets
 make migrate     # Apply migrations
-make run         # Start production server
+make run-prod    # Start production server (no reload)
 ```
 
 ## Project Structure

--- a/python-web/tests/test_makefile.py
+++ b/python-web/tests/test_makefile.py
@@ -41,21 +41,17 @@ def _extract_target_section(content: str, target: str) -> str:
 
 
 class TestRunTargetUvicornFlags:
-    """run ターゲットの uvicorn 起動フラグが現行 uvicorn で有効なこと."""
+    """run (開発) ターゲットの uvicorn 起動フラグが現行 uvicorn で有効なこと.
 
-    def test_run_target_does_not_use_no_reload(self) -> None:
-        """run は --no-reload を含まない (uvicorn 0.44 で削除済み)."""
-        run_section = _extract_target_section(_read_makefile(), "run")
-        assert "--no-reload" not in run_section, (
-            "uvicorn 0.44 では --no-reload が削除された (デフォルト = 非リロード)"
-        )
+    Makefile はローカル開発のみを対象とするため (#143)、
+    `run` は --reload + Tailwind watch を伴う開発モードである。
+    """
 
-    def test_run_target_does_not_enable_reload(self) -> None:
-        """run は --reload を有効化しない (本番モード)."""
-        run_section = _extract_target_section(_read_makefile(), "run")
-        # --reload-xxx は許容、単独 --reload のみ NG
-        assert not re.search(r"--reload(\s|$)", run_section), (
-            f"run target で --reload が有効化されている: {run_section}"
+    def test_run_target_enables_reload(self) -> None:
+        """run は --reload を有効化する (開発モード)."""
+        section = _extract_target_section(_read_makefile(), "run")
+        assert re.search(r"--reload(\s|$)", section), (
+            f"run target で --reload が見つからない: {section}"
         )
 
     def test_run_target_uvicorn_flags_are_accepted_by_uvicorn(self) -> None:
@@ -68,12 +64,14 @@ class TestRunTargetUvicornFlags:
         if not uvicorn_bin.exists():
             pytest.skip(".venv/bin/uvicorn 未インストールのためスキップ")
 
-        run_section = _extract_target_section(_read_makefile(), "run")
-        match = re.search(r"uvicorn\s+([^\n]+)", run_section)
-        assert match, f"uvicorn 起動行が見つからない: {run_section}"
+        section = _extract_target_section(_read_makefile(), "run")
+        match = re.search(r"uvicorn\s+([^\n]+)", section)
+        assert match, f"uvicorn 起動行が見つからない: {section}"
 
-        # 環境変数を展開: $(PORT) → 8000
-        args_str = match.group(1).replace("$(PORT)", "8000")
+        # 環境変数を展開: $$_port → 8000 / $(PORT) → 8000
+        args_str = match.group(1).replace("$$_port", "8000").replace(
+            "$(PORT)", "8000"
+        )
         args = args_str.split()
 
         result = subprocess.run(

--- a/python-web/tests/test_production.py
+++ b/python-web/tests/test_production.py
@@ -1,8 +1,12 @@
-"""Production build and server configuration tests.
+"""Build assets and dev-server configuration tests.
 
-US4: 本番ビルドとデプロイ準備
-- make build で Tailwind CSS が minify される
-- make run で本番モードのサーバーが起動する
+US4: 本番ビルドアセットとローカル開発サーバー
+- make build で Tailwind CSS が minify される (本番アセット)
+- make run でローカル開発モードのサーバーが起動する (--reload + watch)
+
+Makefile はローカル開発のみを対象とする (#143)。本番サーバー起動は
+ホスト環境の責務 (uvicorn 直叩き / gunicorn / Docker など) なので
+Makefile には本番サーバーターゲットは存在しない。
 """
 
 import re
@@ -54,7 +58,7 @@ def _npm_available() -> bool:
 
 
 class TestMakefileBuildTarget:
-    """make build ターゲットの本番ビルド要件テスト."""
+    """make build ターゲットの本番アセットビルド要件テスト."""
 
     def test_build_target_exists_in_makefile(self) -> None:
         """Makefile に build ターゲットが定義されていること."""
@@ -156,35 +160,21 @@ class TestMakefileBuildTarget:
 
 
 class TestMakefileRunTarget:
-    """make run ターゲットの本番サーバー要件テスト."""
+    """make run ターゲットのローカル開発サーバー要件テスト."""
 
     def test_run_target_exists_in_makefile(self) -> None:
         """Makefile に run ターゲットが定義されていること."""
         content = _read_makefile()
-        assert "run:" in content or "run: build" in content
+        assert re.search(r"^run:", content, re.MULTILINE)
 
-    def test_run_target_does_not_enable_reload(self) -> None:
-        """run ターゲットが --reload を有効化しないこと.
-
-        本番サーバーでは自動リロードを無効にする。
-        uvicorn 0.44 では --no-reload フラグは廃止 (デフォルトが非リロード)。
-        """
+    def test_run_target_enables_reload(self) -> None:
+        """run ターゲットが --reload を有効化すること (開発モード)."""
         content = _read_makefile()
         run_section = _extract_target_section(content, "run")
-        assert not re.search(r"--reload(\s|$)", run_section), (
-            "run target で --reload が有効化されている。"
+        assert re.search(r"--reload(\s|$)", run_section), (
+            "run target で --reload が見つからない。"
             f"section: {run_section}"
         )
-
-    def test_run_target_depends_on_build(self) -> None:
-        """run ターゲットが build に依存していること."""
-        content = _read_makefile()
-        lines = content.split("\n")
-        for line in lines:
-            if line.startswith("run:"):
-                assert "build" in line
-                return
-        pytest.fail("run target not found")
 
     def test_run_target_uses_uvicorn(self) -> None:
         """run ターゲットが uvicorn を使用すること."""
@@ -197,7 +187,7 @@ class TestMakefileRunTarget:
         content = _read_makefile()
         assert "PORT" in content
         run_section = _extract_target_section(content, "run")
-        assert "$(PORT)" in run_section
+        assert "PORT" in run_section
 
     def test_run_target_binds_to_all_interfaces(self) -> None:
         """run ターゲットが 0.0.0.0 にバインドすること."""
@@ -205,31 +195,38 @@ class TestMakefileRunTarget:
         run_section = _extract_target_section(content, "run")
         assert "0.0.0.0" in run_section
 
+    def test_run_target_runs_tailwind_watch(self) -> None:
+        """run ターゲットが Tailwind --watch を起動すること."""
+        content = _read_makefile()
+        run_section = _extract_target_section(content, "run")
+        assert "--watch" in run_section, (
+            "run target で Tailwind --watch が見つからない。"
+            f"section: {run_section}"
+        )
 
-class TestDevVsProductionDifferences:
-    """開発モードと本番モードの違いが正しいこと."""
 
-    def test_dev_uses_reload_run_does_not(self) -> None:
-        """dev は --reload あり、run は --reload を含まない.
+class TestNoProductionTargetInMakefile:
+    """Makefile はローカル開発のみを対象とする (#143)."""
 
-        uvicorn 0.44 で --no-reload は廃止されたので、run では --reload を
-        指定しないことで非リロード (デフォルト) 動作にする。
+    def test_no_run_prod_target(self) -> None:
+        """Makefile に run-prod ターゲットが存在しないこと.
+
+        本番サーバー起動はホスト環境の責務とし、Makefile はローカル開発のみ。
         """
         content = _read_makefile()
-        dev_section = _extract_target_section(content, "dev")
-        run_section = _extract_target_section(content, "run")
+        assert not re.search(r"^run-prod:", content, re.MULTILINE), (
+            "run-prod ターゲットが残存している。Makefile はローカル開発のみ"
+        )
 
-        assert "--reload" in dev_section
-        assert not re.search(r"--reload(\s|$)", run_section)
+    def test_no_dev_target(self) -> None:
+        """Makefile に dev ターゲットが存在しないこと.
 
-    def test_dev_uses_tailwind_watch_build_uses_minify(self) -> None:
-        """dev は Tailwind watch、build は minify."""
+        開発サーバーは `run` に統一された (#143)。
+        """
         content = _read_makefile()
-        dev_section = _extract_target_section(content, "dev")
-        build_section = _extract_target_section(content, "build")
-
-        assert "--watch" in dev_section
-        assert "--minify" in build_section
+        assert not re.search(r"^dev:", content, re.MULTILINE), (
+            "dev ターゲットが残存している。run に統一されたはず"
+        )
 
 
 class TestCopyAlpineTarget:

--- a/react-spa-cloudflare/Makefile
+++ b/react-spa-cloudflare/Makefile
@@ -1,63 +1,97 @@
-.PHONY: dev build preview stop status lint format test test-watch test-coverage clean pages-create pages-login deploy deploy-preview
+.PHONY: install run build preview stop status lint lint-fix format format-check \
+	test test-watch test-cov check ci clean \
+	pages-create pages-login deploy deploy-preview help
+
+# Default target
+.DEFAULT_GOAL := help
 
 # Variables
 PORT ?= 5173
 PROJECT_NAME := react-spa-cloudflare
 
-dev:
-	npm run dev
-
-build:
-	npm run build
-
-preview:
-	npm run preview
-
-stop:
-	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
-
-status:
-	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "react-spa: running (:$(PORT))" || echo "react-spa: stopped"
-
-lint:
-	npm run lint
-
-lint-fix:
-	npm run lint:fix
-
-format:
-	npm run format
-
-format-check:
-	npm run format:check
-
-test:
-	npm run test
-
-test-watch:
-	npm run test:watch
-
-test-coverage:
-	npm run test:coverage
-
-clean:
-	rm -rf dist node_modules coverage
-
+## install: Install dependencies
 install:
 	npm install
 
-# Cloudflare Pages setup (run once)
+## run: Start the Vite dev server
+run:
+	npm run dev
+
+## build: Build the production bundle
+build:
+	npm run build
+
+## preview: Preview the production build locally
+preview:
+	npm run preview
+
+## stop: Stop the dev server
+stop:
+	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
+
+## status: Check if the dev server is running
+status:
+	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "react-spa-cloudflare: running (:$(PORT))" || echo "react-spa-cloudflare: stopped"
+
+## lint: Run linter
+lint:
+	npm run lint
+
+## lint-fix: Auto-fix lint issues
+lint-fix:
+	npm run lint:fix
+
+## format: Format source files
+format:
+	npm run format
+
+## format-check: Check formatting without modifying files
+format-check:
+	npm run format:check
+
+## test: Run tests
+test:
+	npm run test
+
+## test-watch: Run tests in watch mode
+test-watch:
+	npm run test:watch
+
+## test-cov: Run tests with coverage
+test-cov:
+	npm run test:coverage
+
+## check: Run lint + test
+check: lint test
+
+## ci: Run lint + format-check + test with coverage + build
+ci: lint format-check test-cov build
+
+## clean: Remove build artifacts
+clean:
+	rm -rf dist node_modules coverage
+
+## pages-login: Authenticate wrangler with Cloudflare (run once)
 pages-login:
 	npx wrangler login
 
+## pages-create: Create the Cloudflare Pages project (run once)
 pages-create:
 	npx wrangler pages project create $(PROJECT_NAME) --production-branch=main
 
-# Cloudflare Pages deployment
+## deploy: Build and deploy to Cloudflare Pages production
 deploy:
 	npm run build
 	npx wrangler pages deploy dist --project-name=$(PROJECT_NAME)
 
+## deploy-preview: Build and deploy to Cloudflare Pages preview branch
 deploy-preview:
 	npm run build
 	npx wrangler pages deploy dist --project-name=$(PROJECT_NAME) --branch=preview
+
+## help: Show this help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'

--- a/react-spa-cloudflare/README.md
+++ b/react-spa-cloudflare/README.md
@@ -107,9 +107,11 @@ npx wrangler pages deploy dist --project-name=react-spa-cloudflare
 
 | Target | Description |
 |--------|-------------|
-| `make dev` | Start development server |
+| `make run` | Start development server |
 | `make build` | Build for production |
 | `make test` | Run tests |
+| `make test-cov` | Run tests with coverage |
+| `make ci` | lint + format-check + test-cov + build |
 | `make deploy` | Deploy to Cloudflare Pages (production) |
 | `make deploy-preview` | Deploy to Cloudflare Pages (preview) |
 | `make clean` | Remove build artifacts |

--- a/react-spa-graphql/Makefile
+++ b/react-spa-graphql/Makefile
@@ -1,55 +1,85 @@
-.PHONY: dev build preview stop status lint format test test-watch test-coverage clean codegen codegen-watch
+.PHONY: install run build preview stop status lint lint-fix format format-check \
+	test test-watch test-cov check ci codegen codegen-watch clean help
+
+# Default target
+.DEFAULT_GOAL := help
 
 # Variables
 PORT ?= 5174
 
-dev:
+## install: Install dependencies
+install:
+	npm install
+
+## run: Start the Vite dev server
+run:
 	npm run dev
 
+## build: Build the production bundle
 build:
 	npm run build
 
+## preview: Preview the production build locally
 preview:
 	npm run preview
 
+## stop: Stop the dev server
 stop:
 	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
 
+## status: Check if the dev server is running
 status:
 	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "react-spa-graphql: running (:$(PORT))" || echo "react-spa-graphql: stopped"
 
+## lint: Run linter
 lint:
 	npm run lint
 
+## lint-fix: Auto-fix lint issues
 lint-fix:
 	npm run lint:fix
 
+## format: Format source files
 format:
 	npm run format
 
+## format-check: Check formatting without modifying files
 format-check:
 	npm run format:check
 
+## test: Run tests
 test:
 	npm run test
 
+## test-watch: Run tests in watch mode
 test-watch:
 	npm run test:watch
 
-test-coverage:
+## test-cov: Run tests with coverage
+test-cov:
 	npm run test:coverage
 
-coverage:
-	npm run test:coverage
+## check: Run lint + test
+check: lint test
 
+## ci: Run lint + format-check + test with coverage + build
+ci: lint format-check test-cov build
+
+## codegen: Generate GraphQL types
 codegen:
 	npm run codegen
 
+## codegen-watch: Generate GraphQL types in watch mode
 codegen-watch:
 	npm run codegen:watch
 
+## clean: Remove build artifacts
 clean:
 	rm -rf dist node_modules coverage src/graphql/generated
 
-install:
-	npm install
+## help: Show this help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'

--- a/react-spa/Makefile
+++ b/react-spa/Makefile
@@ -1,46 +1,77 @@
-.PHONY: dev build preview stop status lint format test test-watch test-coverage clean
+.PHONY: install run build preview stop status lint lint-fix format format-check \
+	test test-watch test-cov check ci clean help
+
+# Default target
+.DEFAULT_GOAL := help
 
 # Variables
 PORT ?= 5173
 
-dev:
+## install: Install dependencies
+install:
+	npm install
+
+## run: Start the Vite dev server
+run:
 	npm run dev
 
+## build: Build the production bundle
 build:
 	npm run build
 
+## preview: Preview the production build locally
 preview:
 	npm run preview
 
+## stop: Stop the dev server
 stop:
 	@lsof -ti :$(PORT) | xargs kill 2>/dev/null || true
 
+## status: Check if the dev server is running
 status:
 	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "react-spa: running (:$(PORT))" || echo "react-spa: stopped"
 
+## lint: Run linter
 lint:
 	npm run lint
 
+## lint-fix: Auto-fix lint issues
 lint-fix:
 	npm run lint:fix
 
+## format: Format source files
 format:
 	npm run format
 
+## format-check: Check formatting without modifying files
 format-check:
 	npm run format:check
 
+## test: Run tests
 test:
 	npm run test
 
+## test-watch: Run tests in watch mode
 test-watch:
 	npm run test:watch
 
-test-coverage:
+## test-cov: Run tests with coverage
+test-cov:
 	npm run test:coverage
 
+## check: Run lint + test
+check: lint test
+
+## ci: Run lint + format-check + test with coverage + build
+ci: lint format-check test-cov build
+
+## clean: Remove build artifacts
 clean:
 	rm -rf dist node_modules coverage
 
-install:
-	npm install
+## help: Show this help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'


### PR DESCRIPTION
Closes #143

## Summary

Makefile ターゲットを `make run` を中心に統一する（#143 方針 A）。`dev` を全廃し、ローカル起動の単一エントリポイントを `run` に揃えた。

## Per-template 変更

| テンプレ | 旧 `run` | 旧 `dev` | 新 `run` | 補助 |
|---------|---------|---------|---------|------|
| go-rest-api | `go run ./cmd/server` | `air` | `air`（hot reload） | `run-bare` = `go run` |
| go-graphql-api | 同上 | 同上 | 同上 | `run-bare` |
| go-grpc-api | 同上 | 同上 | 同上 | `run-bare` |
| go-react-spa | built binary | air + Vite 並列 | air + Vite 並列 | `run-binary` / `run-server` / `run-frontend` |
| go-ssr-web | tailwind-build → go run | （無し） | 変更なし | — |
| go-cli | `go run main.go` | （無し） | 変更なし | — |
| python-cli | `uv run mycli` | （無し） | 変更なし | — |
| python-web | production uvicorn | uvicorn --reload + tailwind --watch | uvicorn --reload + tailwind --watch | `run-prod` = production |
| react-spa | （無し） | `npm run dev` | `npm run dev` | — |
| react-spa-cloudflare | （無し） | `npm run dev` | `npm run dev` | — |
| react-spa-graphql | （無し） | `npm run dev` | `npm run dev` | — |
| rust-cli | `cargo run` | （無し） | 変更なし | — |

`make install`（go-rest-api / go-graphql-api / go-grpc-api）は air を自動インストール。

## ターゲット命名の整合性

- `test-coverage` → `test-cov` に統一（react-* 3 テンプレ）
- `react-spa-graphql/Makefile` の重複 `coverage:` を削除
- React 3 テンプレに `check` / `ci` / `help` / `.DEFAULT_GOAL := help` / `## ` ヘルプコメント を追加
- `python-cli/Makefile` の `help` を共通書式 `@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## /  /'` に揃え、`.DEFAULT_GOAL := help` を追加

## CI / README

- `.github/workflows/scaffold-verify-react.yml`: 旧 `make lint format-check test-coverage build` を `make ci` に統一（react Makefile に `ci` ターゲットができたため）
- READMEs: `make dev` → `make run` 置換、削除されたターゲットを反映
  - `go-rest-api/README.md`, `go-graphql-api/README.md`, `go-grpc-api/README.md`
  - `go-react-spa/README.md`
  - `python-web/README.md`
  - `react-spa-cloudflare/README.md`

## 互換性

- `make dev` は全削除。互換 alias は残さない（boilerplate なのでブレイク許容）
- python-web は `make run` の意味が「production → development」に変わるので注意（production は `make run-prod` へ）
- go API 3 テンプレも `make run` の意味が「plain → hot reload」に変わる（plain は `make run-bare` へ）

## 動作確認

すべてのテンプレで `make help` を実行し、統一書式での出力を確認:

```text
Usage: make [target]

Targets:
  install: ...
  run: ...
  ...
```

## Test plan

- [ ] CI（per-template + scaffold-verify-*）が緑
- [ ] `make run` が各テンプレでローカル起動を実行することをローカルで確認
- [ ] `make ci` が React 3 テンプレで動作することを確認（lint + format-check + test-cov + build）
- [ ] go-react-spa の `make run`（air + Vite 並列）が動作
- [ ] go API 3 テンプレで `make install` が air を入れ、`make run` で hot reload する
