### PR TITLE
[WIP] fix(scaffold): BSD sed compatibility for paths with spaces (#182)

### DIFF
--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -40,6 +40,26 @@ ARTIFACTS=(
   tmp
 )
 
+# Portable sed -i (GNU/BSD compatible).
+#
+# GNU sed (Linux): `sed -i 's|x|y|' file`
+# BSD sed (macOS): `sed -i '' 's|x|y|' file` — `-i` requires an extension
+# argument, so without `''` BSD sed parses the substitution expression as the
+# extension and the file path as the script, silently mangling absolute paths
+# that contain spaces (#182).
+#
+# Use `sed_inplace ARGS...` for direct calls, and `sed "${SED_INPLACE_ARGS[@]}"`
+# for `find -exec` so the array expands before find sees it.
+if sed --version 2>/dev/null | grep -q GNU; then
+  SED_INPLACE_ARGS=(-i)
+else
+  SED_INPLACE_ARGS=(-i '')
+fi
+
+sed_inplace() {
+  sed "${SED_INPLACE_ARGS[@]}" "$@"
+}
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/scaffold/lib/compose.sh
+++ b/scripts/scaffold/lib/compose.sh
@@ -104,11 +104,11 @@ compose_template() {
           "$base_dest/package.json" "$pkg_name"
       else
         # Fallback: sed-edit the "name" field. Keeps formatting roughly intact.
-        sed -i "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package.json"
+        sed_inplace "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package.json"
       fi
     fi
     if [[ -f "$base_dest/package-lock.json" ]]; then
-      sed -i "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package-lock.json"
+      sed_inplace "s|\"name\": *\"[^\"]*\"|\"name\": \"$pkg_name\"|" "$base_dest/package-lock.json"
     fi
   fi
 

--- a/scripts/scaffold/lib/go.sh
+++ b/scripts/scaffold/lib/go.sh
@@ -14,19 +14,19 @@ apply_go_replacements() {
   info "Replacing Go module: $old_module -> $module"
 
   # Replace module path in go.mod
-  sed -i "s|^module ${old_module}$|module ${module}|" "$dest/go.mod"
+  sed_inplace "s|^module ${old_module}$|module ${module}|" "$dest/go.mod"
 
   # Replace import paths in all .go files
-  find "$dest" -name '*.go' -exec sed -i "s|\"${old_module}/|\"${module}/|g" {} +
+  find "$dest" -name '*.go' -exec sed "${SED_INPLACE_ARGS[@]}" "s|\"${old_module}/|\"${module}/|g" {} +
 
   # Handle gqlgen.yml autobind (go-graphql-api)
   if [[ -f "$dest/gqlgen.yml" ]]; then
-    sed -i "s|\"${old_module}/|\"${module}/|g" "$dest/gqlgen.yml"
+    sed_inplace "s|\"${old_module}/|\"${module}/|g" "$dest/gqlgen.yml"
   fi
 
   # Handle .golangci.yml local-prefixes
   if [[ -f "$dest/.golangci.yml" ]]; then
-    sed -i "s|${old_module}|${module}|g" "$dest/.golangci.yml"
+    sed_inplace "s|${old_module}|${module}|g" "$dest/.golangci.yml"
   fi
 
   # For CLI templates: replace binary name references (Cobra Use field, version strings, Makefile BINARY_NAME)
@@ -34,8 +34,8 @@ apply_go_replacements() {
     local bin_name
     bin_name="$(basename "$module")"
     # Replace mycli as CLI name in .go files (Cobra Use, version strings, descriptions)
-    find "$dest" -name '*.go' -exec sed -i "s|mycli|${bin_name}|g" {} +
+    find "$dest" -name '*.go' -exec sed "${SED_INPLACE_ARGS[@]}" "s|mycli|${bin_name}|g" {} +
     # Replace BINARY_NAME in Makefile
-    sed -i "s|^BINARY_NAME := mycli|BINARY_NAME := ${bin_name}|" "$dest/Makefile"
+    sed_inplace "s|^BINARY_NAME := mycli|BINARY_NAME := ${bin_name}|" "$dest/Makefile"
   fi
 }

--- a/scripts/scaffold/lib/python.sh
+++ b/scripts/scaffold/lib/python.sh
@@ -22,16 +22,16 @@ apply_python_replacements() {
   # Replace pyproject.toml fields
   if [[ -f "$dest/pyproject.toml" ]]; then
     # Replace project name
-    sed -i "s|^name = \"${orig_pkg}\"|name = \"${name}\"|" "$dest/pyproject.toml"
+    sed_inplace "s|^name = \"${orig_pkg}\"|name = \"${name}\"|" "$dest/pyproject.toml"
 
     # Replace scripts entry (python-cli only)
-    sed -i "s|^${orig_pkg} = \"${orig_pkg}\.|${pkg_name} = \"${pkg_name}.|" "$dest/pyproject.toml"
+    sed_inplace "s|^${orig_pkg} = \"${orig_pkg}\.|${pkg_name} = \"${pkg_name}.|" "$dest/pyproject.toml"
 
     # Replace hatch build packages
-    sed -i "s|\"src/${orig_pkg}\"|\"src/${pkg_name}\"|g" "$dest/pyproject.toml"
+    sed_inplace "s|\"src/${orig_pkg}\"|\"src/${pkg_name}\"|g" "$dest/pyproject.toml"
 
     # Replace coverage source
-    sed -i "s|source = \[\"src/${orig_pkg}\"\]|source = [\"src/${pkg_name}\"]|g" "$dest/pyproject.toml"
+    sed_inplace "s|source = \[\"src/${orig_pkg}\"\]|source = [\"src/${pkg_name}\"]|g" "$dest/pyproject.toml"
 
     info "Updated pyproject.toml"
   fi
@@ -43,7 +43,7 @@ apply_python_replacements() {
   fi
 
   # Replace import references, string literals, and comments in .py files
-  find "$dest" -name '*.py' -exec sed -i \
+  find "$dest" -name '*.py' -exec sed "${SED_INPLACE_ARGS[@]}" \
     "s|from ${orig_pkg}|from ${pkg_name}|g; \
      s|import ${orig_pkg}|import ${pkg_name}|g; \
      s|\"${orig_pkg}\"|\"${name}\"|g; \
@@ -55,22 +55,22 @@ apply_python_replacements() {
 
   # Replace references in Makefile
   if [[ -f "$dest/Makefile" ]]; then
-    sed -i "s|${orig_pkg}|${pkg_name}|g" "$dest/Makefile"
+    sed_inplace "s|${orig_pkg}|${pkg_name}|g" "$dest/Makefile"
     info "Updated Makefile references"
   fi
 
   # Replace references in alembic.ini (python-web batteries-included template)
   if [[ -f "$dest/alembic.ini" ]]; then
-    sed -i "s|src/${orig_pkg}|src/${pkg_name}|g" "$dest/alembic.ini"
+    sed_inplace "s|src/${orig_pkg}|src/${pkg_name}|g" "$dest/alembic.ini"
     info "Updated alembic.ini references"
   fi
 
   # Replace pytest coverage source in CI workflow references
-  find "$dest" -name '*.yml' -exec sed -i "s|--cov=src/${orig_pkg}|--cov=src/${pkg_name}|g" {} + 2>/dev/null || true
+  find "$dest" -name '*.yml' -exec sed "${SED_INPLACE_ARGS[@]}" "s|--cov=src/${orig_pkg}|--cov=src/${pkg_name}|g" {} + 2>/dev/null || true
 
   # python-web specific: replace package.json name field
   if [[ "$template" == "python-web" && -f "$dest/package.json" ]]; then
-    sed -i "s|\"name\": \"${orig_pkg}\"|\"name\": \"${name}\"|" "$dest/package.json"
+    sed_inplace "s|\"name\": \"${orig_pkg}\"|\"name\": \"${name}\"|" "$dest/package.json"
     info "Updated package.json name"
   fi
 }

--- a/scripts/scaffold/lib/react.sh
+++ b/scripts/scaffold/lib/react.sh
@@ -8,18 +8,18 @@ apply_react_replacements() {
 
   # Replace package.json name field
   if [[ -f "$dest/package.json" ]]; then
-    sed -i "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package.json"
+    sed_inplace "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package.json"
     info "Updated package.json name"
   fi
 
   # Replace package-lock.json name field (will be regenerated on npm install, but keep consistent)
   if [[ -f "$dest/package-lock.json" ]]; then
-    sed -i "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package-lock.json"
+    sed_inplace "s|\"name\": \"${template}\"|\"name\": \"${name}\"|" "$dest/package-lock.json"
   fi
 
   # Replace wrangler.toml name (react-spa-cloudflare)
   if [[ -f "$dest/wrangler.toml" ]]; then
-    sed -i "s|^name = \"${template}\"|name = \"${name}\"|" "$dest/wrangler.toml"
+    sed_inplace "s|^name = \"${template}\"|name = \"${name}\"|" "$dest/wrangler.toml"
     info "Updated wrangler.toml name"
   fi
 }

--- a/scripts/scaffold/lib/rust.sh
+++ b/scripts/scaffold/lib/rust.sh
@@ -11,32 +11,32 @@ apply_rust_replacements() {
 
   # Replace Cargo.toml package name
   if [[ -f "$dest/Cargo.toml" ]]; then
-    sed -i "s|^name = \"rust-cli\"|name = \"${name}\"|" "$dest/Cargo.toml"
+    sed_inplace "s|^name = \"rust-cli\"|name = \"${name}\"|" "$dest/Cargo.toml"
     # Replace bin name
-    sed -i "s|^name = \"mycli\"|name = \"${name}\"|" "$dest/Cargo.toml"
+    sed_inplace "s|^name = \"mycli\"|name = \"${name}\"|" "$dest/Cargo.toml"
     info "Updated Cargo.toml"
   fi
 
   # Replace command name in src/cli.rs
   if [[ -f "$dest/src/cli.rs" ]]; then
-    sed -i "s|command(name = \"mycli\")|command(name = \"${name}\")|" "$dest/src/cli.rs"
+    sed_inplace "s|command(name = \"mycli\")|command(name = \"${name}\")|" "$dest/src/cli.rs"
     # Replace crate import (rust_cli -> new crate name)
-    sed -i "s|use rust_cli::|use ${crate_name}::|g" "$dest/src/cli.rs"
+    sed_inplace "s|use rust_cli::|use ${crate_name}::|g" "$dest/src/cli.rs"
     info "Updated src/cli.rs"
   fi
 
   # Replace crate import in src/main.rs (rust_cli -> new crate name)
   if [[ -f "$dest/src/main.rs" ]]; then
-    sed -i "s|use rust_cli::|use ${crate_name}::|g" "$dest/src/main.rs"
+    sed_inplace "s|use rust_cli::|use ${crate_name}::|g" "$dest/src/main.rs"
     info "Updated src/main.rs"
   fi
 
   # Replace BINARY_NAME in Makefile
   if [[ -f "$dest/Makefile" ]]; then
-    sed -i "s|^BINARY_NAME := mycli|BINARY_NAME := ${name}|" "$dest/Makefile"
+    sed_inplace "s|^BINARY_NAME := mycli|BINARY_NAME := ${name}|" "$dest/Makefile"
     info "Updated Makefile BINARY_NAME"
   fi
 
   # Replace binary name in test files (assert_cmd's cargo_bin("mycli"))
-  find "$dest/tests" -name '*.rs' -exec sed -i "s|\"mycli\"|\"${name}\"|g" {} + 2>/dev/null || true
+  find "$dest/tests" -name '*.rs' -exec sed "${SED_INPLACE_ARGS[@]}" "s|\"mycli\"|\"${name}\"|g" {} + 2>/dev/null || true
 }

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -77,7 +77,7 @@ transform_ci_workflows "$dest" "$REPO_ROOT" "$template" "$name"
 generic_files="$(grep -rl "${template}" "$dest" --include='*.html' --include='Makefile' --include='*.graphql' 2>/dev/null || true)"
 if [[ -n "$generic_files" ]]; then
   while IFS= read -r f; do
-    sed -i "s|${template}|${name}|g" "$f"
+    sed_inplace "s|${template}|${name}|g" "$f"
   done <<< "$generic_files"
 fi
 


### PR DESCRIPTION
## 概要

`scripts/download.sh` を空白を含む宛先パス（例: `/Users/foo/My Workspace/backlog-mentions`）に対して走らせると、BSD sed (macOS デフォルト) が `sed -i 's|x|y|' file` の引数形式を解釈できず、テンプレ展開は完走するのにモジュール名置換だけが silent skip される問題を修正。

## 根本原因

- GNU sed: `sed -i 's|x|y|' file` （extension 不要）
- BSD sed: `sed -i '' 's|x|y|' file` （extension 引数が必須）

BSD sed は `-i` の直後の引数を extension として食うため、置換式が extension に化け、ファイルパスが script として解釈されて失敗する。

## 変更点

- `scripts/scaffold/lib/common.sh`: `SED_INPLACE_ARGS` 配列と `sed_inplace` ヘルパー関数を追加。`sed --version` で GNU/BSD を判定。
- `scripts/scaffold/scaffold.sh` と `lib/{go,python,react,rust,compose}.sh` の全 `sed -i` 呼び出しを置換。
- `find -exec` には配列展開を使用 (`find ... -exec sed "${SED_INPLACE_ARGS[@]}" "..." {} +`)。

## 動作確認

Linux 上で空白を含む宛先パスに対して以下を scaffold して、モジュール名・パッケージ名が正しく置換されることを確認:

- `go-ssr-web` → `go.mod` の `module backlog-mentions`、`*.go` の import パス書き換え OK
- `react-spa` → `package.json` の `name` 書き換え OK
- `python-web` → `pyproject.toml` の `name` 書き換え OK

macOS (BSD sed) での実機検証はレビュア側にお願いしたい。

Closes #182