### PR TITLE
fix(go-ssr-web): simplify //go:embed to top-level dirs

### DIFF
--- a/go-ssr-web/web/embed.go
+++ b/go-ssr-web/web/embed.go
@@ -2,5 +2,5 @@ package web
 
 import "embed"
 
-//go:embed templates templates/users static static/css static/icons
+//go:embed templates static
 var FS embed.FS


### PR DESCRIPTION
## 概要 [AI]
`go-ssr-web/web/embed.go` の `//go:embed` ディレクティブが、`embed` パッケージが本来再帰的に拾うサブディレクトリを明示列挙しており、利用者が `templates/users` や `static/icons` を削除した瞬間に `pattern ...: no matching files found` でビルドが壊れる問題を解消。

## 関連 Issue [AI]
Closes #183

## 変更タイプ [AI]
- [x] fix: バグ修正

## 動作確認手順（ローカル起動） [人]

\`\`\`bash
cd go-ssr-web
make ci
make run
\`\`\`

### 動作確認シナリオ [人]
- [ ] `make ci` が PASS する（lint / test 緑）
- [ ] `make run` でサーバー起動、`/` `/login` `/users` が描画される
- [ ] `templates/users/` を削除しても `go build ./cmd/server` がコンパイルできる

## テスト [AI]
- [x] `make ci` PASS（lint 0 issues / test coverage 65.4%）
- [ ] 新規/変更コードに対するユニットテストを追加した
  - 1行のディレクティブ修正のためテスト追加なし（既存の embed FS 経由のハンドラーテストでカバー済み）

## DB / マイグレーション（該当時のみ） [AI]
- 該当なし

## チェックリスト [AI]
- [ ] README の更新が必要なら反映した
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが \`main\`

## 補足 / レビュー観点 [AI]
- `all:templates all:static` ではなく素の `templates static` を採用。現時点で embed したい dotfile（`.gitkeep` 等）は無く、Go コミュニティの最小列挙プラクティスに揃えるため。将来 dotfile を embed する必要が出たら `all:` プレフィクスを追加する。
- 同パターンを `go-react-spa/internal/static/static_embed.go` でも確認したが、こちらは既に `all:dist` で問題なし。