### PR TITLE
feat(go-ssr-web,go-ssr-web-minimal): auto-discover cmd/* in build

### DIFF
--- a/go-ssr-web-minimal/Makefile
+++ b/go-ssr-web-minimal/Makefile
@@ -4,18 +4,28 @@
 .DEFAULT_GOAL := help
 
 # Variables
-BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 8083
+
+# Auto-discover entry points under cmd/<name>/. Adding cmd/foo/main.go is
+# sufficient — `make build` will produce bin/foo without further edits.
+CMDS := $(notdir $(wildcard cmd/*))
+BINARIES := $(addprefix $(BIN_DIR)/,$(CMDS))
+.PHONY: $(BINARIES)
 
 ## install: Download dependencies
 install:
 	go mod download
 
-## build: Build the binary
-build:
-	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
+## build: Build all cmd/* binaries
+build: $(BINARIES)
+
+# Static pattern rule restricted to $(BINARIES) so it only matches discovered
+# cmd/* entry points, not any other file that may live under bin/.
+$(BINARIES): $(BIN_DIR)/%:
+	@mkdir -p $(BIN_DIR)
+	go build -o $@ ./cmd/$*
 
 ## run: Run the server
 run:

--- a/go-ssr-web/Makefile
+++ b/go-ssr-web/Makefile
@@ -4,12 +4,17 @@
 .DEFAULT_GOAL := help
 
 # Variables
-BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 8082
 TAILWIND_VERSION ?= v4.1.5
 TAILWIND_BIN := $(BIN_DIR)/tailwindcss
+
+# Auto-discover entry points under cmd/<name>/. Adding cmd/foo/main.go is
+# sufficient — `make build` will produce bin/foo without further edits.
+CMDS := $(notdir $(wildcard cmd/*))
+BINARIES := $(addprefix $(BIN_DIR)/,$(CMDS))
+.PHONY: $(BINARIES)
 
 ## install: Download dependencies
 install:
@@ -32,9 +37,14 @@ tailwind-install:
 tailwind-build: tailwind-install
 	$(TAILWIND_BIN) -i web/static/css/input.css -o web/static/css/output.css --minify
 
-## build: Build the binary and Tailwind CSS
-build: tailwind-build
-	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
+## build: Build all cmd/* binaries and Tailwind CSS
+build: tailwind-build $(BINARIES)
+
+# Static pattern rule restricted to $(BINARIES) so it can't accidentally match
+# other files under bin/ (e.g. bin/tailwindcss, which is fetched by curl).
+$(BINARIES): $(BIN_DIR)/%:
+	@mkdir -p $(BIN_DIR)
+	go build -o $@ ./cmd/$*
 
 ## run: Run the server (Tailwind CSS をビルドしてから起動)
 run: tailwind-build


### PR DESCRIPTION
## 概要 [AI]
\`go-ssr-web\` / \`go-ssr-web-minimal\` の \`Makefile\` を、\`cmd/<name>/\` を自動検出して全部ビルドする汎用ルールに置き換える。\`cmd/foo/main.go\` を追加しただけで \`bin/foo\` が作られるようになり、\`BINARY_NAME\` 1 個前提の書き換えが不要になる。\`run\` ターゲットは server 固定で OK なため変更なし。

## 関連 Issue [AI]
Closes #186

## 変更タイプ [AI]
- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動） [人]

\`\`\`bash
# go-ssr-web: server / migrate の両方が bin/ に出ることを確認
cd go-ssr-web
rm -rf bin
make build
ls bin/
# 期待: migrate, server, tailwindcss

# go-ssr-web-minimal: cmd/foo を追加すると bin/foo が自動で出ることを確認
cd ../go-ssr-web-minimal
mkdir -p cmd/foo && printf 'package main\nfunc main(){}\n' > cmd/foo/main.go
rm -rf bin
make build
ls bin/
# 期待: foo, server
rm -rf cmd/foo bin
\`\`\`

### 動作確認シナリオ [人]
- [ ] \`go-ssr-web\` の \`make build\` で \`bin/server\` と \`bin/migrate\` が両方できる
- [ ] \`go-ssr-web-minimal\` で \`cmd/foo/main.go\` を追加したあと \`make build\` で \`bin/foo\` が自動で作られる
- [ ] \`make ci\` が PASS（lint + test-cov）
- [ ] \`scaffold.sh\` で出力したプロジェクトでも \`make build\` が動く

## テスト [AI]
- [x] \`make ci\` PASS（go-ssr-web / go-ssr-web-minimal 両方）
- [x] \`scaffold.sh\` 出力先でも \`make build\` で全 cmd/* がビルドされることを確認
- [x] 新規/変更コードに対するユニットテストを追加した（Makefile 変更のみ、テストは既存をそのまま使用）

## チェックリスト [AI]
- [x] README の更新が必要なら反映した（不要: ターゲット名・ふるまいは互換）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが \`main\`

## 補足 / レビュー観点 [AI]
- Issue 提案の素朴な pattern rule \`$(BIN_DIR)/%: cmd/%/*.go\` は GNU Make が prerequisite の \`*\` をリテラル扱いするため期待通りに展開されない。代わりに \`$(BINARIES): $(BIN_DIR)/%:\` の **静的パターンルール** にして、\`BINARIES\` を \`.PHONY\` に登録、ステイル判定は Go のビルドキャッシュに委ねる方式を採用した。
- 静的パターンにすることで \`bin/tailwindcss\`（curl で取得する CLI バイナリ）など \`cmd/*\` 由来でないファイルをこのルールが誤って拾わないことを保証している。
- \`go-ssr-web-minimal\` も同じパターンを抱えていたため同時に適用（現在は \`cmd/server\` のみだが将来 \`cmd/foo\` を足したときに自動で乗る）。
- \`run\` は HTTP エントリポイント固定の \`./cmd/server\` のままで Issue の指示通り。