### PR TITLE
[WIP] perf(ci): e2e ワークフロー短縮 — npm cache / 事前ビルド / 並列度

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,25 +47,46 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            react-spa-graphql/package-lock.json
+            react-spa/package-lock.json
+            react-spa-cloudflare/package-lock.json
+            e2e/package-lock.json
 
       - name: Install React SPA GraphQL dependencies
         working-directory: react-spa-graphql
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Install React SPA dependencies
         working-directory: react-spa
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Install React SPA Cloudflare dependencies
         working-directory: react-spa-cloudflare
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Install E2E dependencies
         working-directory: e2e
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Build go-graphql-api binary
+        working-directory: go-graphql-api
+        env:
+          CGO_ENABLED: "0"
+        run: go build -o /tmp/go-graphql-api ./cmd/server
+
+      - name: Build go-rest-api binary
+        working-directory: go-rest-api
+        env:
+          CGO_ENABLED: "0"
+        run: go build -o /tmp/go-rest-api ./cmd/server
 
       - name: Run E2E tests (integration + VRT + a11y)
         working-directory: e2e
+        env:
+          GO_GRAPHQL_API_BIN: /tmp/go-graphql-api
+          GO_REST_API_BIN: /tmp/go-rest-api
         run: npx playwright test
 
       - name: Upload test artifacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,13 +74,13 @@ jobs:
         working-directory: go-graphql-api
         env:
           CGO_ENABLED: "0"
-        run: go build -o /tmp/go-graphql-api ./cmd/server
+        run: go build -buildvcs=false -o /tmp/go-graphql-api ./cmd/server
 
       - name: Build go-rest-api binary
         working-directory: go-rest-api
         env:
           CGO_ENABLED: "0"
-        run: go build -o /tmp/go-rest-api ./cmd/server
+        run: go build -buildvcs=false -o /tmp/go-rest-api ./cmd/server
 
       - name: Run E2E tests (integration + VRT + a11y)
         working-directory: e2e

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? "github" : "html",
   timeout: 30_000,
   expect: {
@@ -65,13 +65,17 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "cd ../go-graphql-api && go run ./cmd/server",
+      command: process.env.GO_GRAPHQL_API_BIN
+        ? process.env.GO_GRAPHQL_API_BIN
+        : "cd ../go-graphql-api && go run ./cmd/server",
       url: "http://localhost:8080/health",
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
     },
     {
-      command: "cd ../go-rest-api && PORT=8081 go run ./cmd/server",
+      command: process.env.GO_REST_API_BIN
+        ? `PORT=8081 ${process.env.GO_REST_API_BIN}`
+        : "cd ../go-rest-api && PORT=8081 go run ./cmd/server",
       url: "http://localhost:8081/health",
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,


### PR DESCRIPTION
Closes #195

## 変更内容（Quick win 中心）

### npm install 高速化
- `actions/setup-node@v6` に `cache: 'npm'` + 4 つの `package-lock.json` を `cache-dependency-path` に指定
- `npm ci` に `--prefer-offline --no-audit --no-fund` を付与

### Go サーバー起動の事前ビルド化
- `go-graphql-api` / `go-rest-api` を CI ステップで `go build -o /tmp/...` し、Playwright webServer は `GO_GRAPHQL_API_BIN` / `GO_REST_API_BIN` があればバイナリを起動（無ければ従来通り `go run`）
- ローカルでは環境変数を設定しないため挙動は変わらない

### 並列度
- CI の Playwright `workers` を 1 → 2 に引き上げ（メモリ競合リスクは低めの引き上げ）

## まだやっていないこと（次の PR 候補）

- Vite ビルドを workflow ステップ側で並列実行
- Playwright image を container 化せずに `npx playwright install` へ切替
- テンプレート別 matrix ジョブ化
- VRT を nightly に分離

## Test plan

- [ ] CI の e2e ワークフローが通る
- [ ] step 別の所要時間で `Install React SPA GraphQL deps` が大幅短縮されている
- [ ] `Run E2E tests` が短縮されている（事前ビルド + workers=2 効果）
- [ ] VRT スナップショットが壊れていない