### PR TITLE
refactor(go-ssr-web): auto-discover templates via fs.WalkDir

### DIFF
--- a/go-ssr-web/cmd/server/main.go
+++ b/go-ssr-web/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -137,23 +138,29 @@ func main() {
 // "content" definition. A single shared set causes {{define "content"}} to be
 // overwritten by the last-parsed file, breaking all but the final page.
 func loadTemplates() (map[string]*template.Template, error) {
-	pages := []struct{ name, path string }{
-		{"index.html", "templates/index.html"},
-		{"login.html", "templates/login.html"},
-		{"profile.html", "templates/profile.html"},
-		{"users/index.html", "templates/users/index.html"},
-		{"users/new.html", "templates/users/new.html"},
-		{"users/show.html", "templates/users/show.html"},
-		{"users/edit.html", "templates/users/edit.html"},
-	}
+	const (
+		root   = "templates"
+		layout = "templates/base.html"
+	)
 
-	m := make(map[string]*template.Template, len(pages))
-	for _, p := range pages {
-		t, err := template.ParseFS(web.FS, "templates/base.html", p.path)
+	m := map[string]*template.Template{}
+	err := fs.WalkDir(web.FS, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return nil, fmt.Errorf("loading template %s: %w", p.name, err)
+			return err
 		}
-		m[p.name] = t
+		if d.IsDir() || path == layout || !strings.HasSuffix(path, ".html") {
+			return nil
+		}
+		name := strings.TrimPrefix(path, root+"/")
+		t, perr := template.ParseFS(web.FS, layout, path)
+		if perr != nil {
+			return fmt.Errorf("loading template %s: %w", name, perr)
+		}
+		m[name] = t
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return m, nil
 }


### PR DESCRIPTION
## 概要 [AI]
`cmd/server/main.go` の `loadTemplates()` がページ一覧をハードコードしていたのを、`fs.WalkDir` ベースの自動ディスカバリに置き換えた。`web/templates/` 配下にテンプレートを追加・削除するだけで `main.go` を編集する必要がなくなる。

per-page テンプレートセット（各ページが固有の `{{define \"content\"}}` を持つ）の設計意図は維持している。

## 関連 Issue [AI]
Closes #185

## 変更タイプ [AI]
- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動） [人]

\`\`\`bash
cd go-ssr-web
make ci
make run
# http://localhost:8082/ でトップ・/login・/users 等が描画されること
\`\`\`

### 動作確認シナリオ [人]
- [ ] \`/\` (index.html) が描画される
- [ ] \`/login\` (login.html) が描画される
- [ ] \`/users\`, \`/users/new\`, \`/users/:id\`, \`/users/:id/edit\` が描画される

## テスト [AI]
- [x] \`make ci\` PASS
- [ ] 新規/変更コードに対するユニットテストを追加した
  - 既存の handler テスト群が全テンプレートのレンダリングを通しでカバーしているため、loadTemplates 自体の単体テストは追加していない（追加が望ましければ別タスクで対応）。

## DB / マイグレーション（該当時のみ） [AI]
- [ ] スキーマ変更の内容と適用手順を **概要** セクションに記載した
  - DB 変更なし

## チェックリスト [AI]
- [ ] README の更新が必要なら反映した（不要）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが \`main\`

## 補足 / レビュー観点 [AI]
- 走査順は \`fs.WalkDir\` の lexical order に依存する。テンプレートマップなので呼び出し順には影響しない。
- \`base.html\` はレイアウトのため明示的にスキップ。\`.html\` 以外のファイルが将来 \`templates/\` 配下に置かれた場合も無視する。
- 既存挙動の互換性: 旧ハードコード一覧と同じ 7 ファイル（index/login/profile/users/{index,new,show,edit}）が登録されることを確認済み。