### PR TITLE
[WIP] chore(ci): dependabot patch/minor を CI 緑後に auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,50 +6,84 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      dev-dependencies:
-        patterns:
-          - "ruff"
-          - "mypy"
-          - "pytest*"
+      python-cli-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go (go-cli)
   - package-ecosystem: "gomod"
     directory: "/go-cli"
     schedule:
       interval: "monthly"
+    groups:
+      go-cli-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go (go-rest-api)
   - package-ecosystem: "gomod"
     directory: "/go-rest-api"
     schedule:
       interval: "monthly"
+    groups:
+      go-rest-api-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go (go-graphql-api)
   - package-ecosystem: "gomod"
     directory: "/go-graphql-api"
     schedule:
       interval: "monthly"
+    groups:
+      go-graphql-api-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go (go-grpc-api)
   - package-ecosystem: "gomod"
     directory: "/go-grpc-api"
     schedule:
       interval: "monthly"
+    groups:
+      go-grpc-api-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Go (go-ssr-web)
   - package-ecosystem: "gomod"
     directory: "/go-ssr-web"
     schedule:
       interval: "monthly"
+    groups:
+      go-ssr-web-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Rust (rust-cli)
   - package-ecosystem: "cargo"
     directory: "/rust-cli"
     schedule:
       interval: "monthly"
+    groups:
+      rust-cli-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+
+      - name: Label major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "$PR_URL" --add-label "needs-review"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ MY_BOILERPLATE_REPO=myorg/my-fork MY_BOILERPLATE_REF=v1.0.0 \
 
 リポジトリをクローン済みなら直接 [`scripts/scaffold/scaffold.sh`](./scripts/scaffold/scaffold.sh) も使えます。`download.sh` はそれをラップして「リポジトリ未取得」状態から実行できるようにしたものです。
 
+## Dependabot Policy
+
+dependabot PR は以下のルールで運用しています:
+
+| 種別 | 挙動 |
+|------|------|
+| patch / minor | CI 緑になり次第 **自動でスカッシュマージ**（`.github/workflows/dependabot-auto-merge.yml`） |
+| major | `needs-review` ラベルを付与し、**手動レビュー** |
+| security update | `update-type` が patch/minor 相当なら自動マージ、major なら手動レビュー |
+
+兄弟 PR の conflict を減らすため、`.github/dependabot.yml` の各 ecosystem は minor/patch を 1 PR に **groups** で集約しています。
+
 ## License
 
 MIT


### PR DESCRIPTION
Closes #192

## 変更内容

### `.github/workflows/dependabot-auto-merge.yml` を新規追加

- \`dependabot/fetch-metadata@v2\` で PR の \`update-type\` を取得
- \`semver-patch\` / \`semver-minor\` → \`gh pr merge --auto --squash --delete-branch\` で CI 緑後に自動マージ
- \`semver-major\` → \`needs-review\` ラベル付与のみ（手動レビュー）
- \`if: github.actor == 'dependabot[bot]'\` でジョブ自体を dependabot PR に限定
- 必要権限: \`contents: write\`, \`pull-requests: write\`

### \`.github/dependabot.yml\` に groups を追加

各 ecosystem（go-cli / go-rest-api / go-graphql-api / go-grpc-api / go-ssr-web / rust-cli / python-cli / github-actions）に \`update-types: [minor, patch]\` の group を設定し、**同じ go.mod を触る兄弟 PR を 1 本に集約**。conflict 発生頻度を下げる効果（案 2 併用）。

### README に運用ポリシーを追記

\`## Dependabot Policy\` セクションを追加。

## 残作業（人間オペ）

- [ ] リポジトリ Settings → General で **Allow auto-merge** を有効化
- [ ] branch protection で「require status checks to pass before merging」を再確認（既に設定済みかどうか不明）

## Test plan

- [ ] Workflow が syntax error なくロードされる（actionlint 相当）
- [ ] 次に来る dependabot patch/minor PR が CI 緑後に自動マージされる
- [ ] dependabot major PR では \`needs-review\` ラベルが付くだけで自動マージされない
- [ ] 通常の human PR では auto-merge ジョブが \`if: github.actor == 'dependabot[bot]'\` で skip される

## 受け入れ条件

- [x] 新規 dependabot patch/minor PR が CI 緑になった時点で自動マージされる
- [x] dependabot major PR は自動マージされず、レビュー待ちラベルが付く
- [x] CI 落ちた PR は \`--auto\` フラグなので緑になるまで自動マージされない