### PR TITLE
fix(go-cli): add tools.go to pin testify dependency

### DIFF
--- a/go-cli/tools.go
+++ b/go-cli/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+
+package tools
+
+import (
+	_ "github.com/stretchr/testify/assert"
+	_ "github.com/stretchr/testify/require"
+)

--- a/go-cli/tools.go
+++ b/go-cli/tools.go
@@ -1,5 +1,7 @@
 //go:build tools
 
+// Package tools pins test-only dependencies so go mod tidy does not remove them.
+// This file is excluded from normal builds by the "tools" build tag.
 package tools
 
 import (


### PR DESCRIPTION
## 概要 [AI]

`go-cli` テンプレートで `go mod tidy` を実行すると `testify` が削除される問題を修正。
`//go:build tools` タグ付きの `tools.go` を追加し、`testify/assert` と `testify/require` をピン留めする。
これにより scaffold 後に `go mod tidy` を実行しても `go.mod` の意図した状態が保たれる。

## 関連 Issue [AI]
Closes #204

## 変更タイプ [AI]
- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動） [人]

```bash
cd go-cli
go mod tidy
grep "testify" go.mod
# → github.com/stretchr/testify v1.11.1 が残っていることを確認
go test ./...
```

### 動作確認シナリオ [人]
- [ ] `go mod tidy` 実行後も `go.mod` に testify が残っている
- [ ] `go test ./...` が全て PASS する
- [ ] `go build` が正常に通る

## テスト [AI]
- [x] `make ci` PASS
- [ ] 新規/変更コードに対するユニットテストを追加した（tools.go はビルドタグのみ、テスト不要）

## DB / マイグレーション（該当時のみ） [AI]
- [ ] スキーマ変更の内容と適用手順を **概要** セクションに記載した

## チェックリスト [AI]
- [x] README の更新が必要なら反映した（変更なし）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点 [AI]

`//go:build tools` は Go コミュニティで標準的な手法（golang/tools リポジトリでも採用）。
通常ビルドには含まれず、`go mod tidy` が依存として保持し続けるため boilerplate の意図を維持できる。
CI の `go mod tidy && git diff --exit-code go.mod go.sum` によるドリフト検出も確実に機能する。
