### PR TITLE
[WIP] bug(go-react-spa): .golangci.yml 未同梱により node_modules の Go ファイルで lint CI が必ず失敗する

### DIFF
--- a/go-react-spa/.golangci.yml
+++ b/go-react-spa/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  exclusions:
+    paths:
+      - frontend/node_modules


### PR DESCRIPTION
## 概要

`go-react-spa` テンプレートに `.golangci.yml` が存在しないため、scaffold 後に `golangci-lint run` を実行すると `frontend/node_modules` 内の Go ファイル（`flatted` パッケージの `flatted.go` 等）が lint 対象として拾われ CI が必ず失敗していた。
golangci-lint v2 の正しいキー `linters.exclusions.paths` で `frontend/node_modules` を除外する `.golangci.yml` をテンプレートに追加することで修正する。

## 関連 Issue

Closes: #207

## Affects

なし

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

```bash
# go-react-spa を scaffold
bash scripts/download.sh go-react-spa /tmp/test-go-react-spa

cd /tmp/test-go-react-spa

# node_modules を生成
cd frontend && npm ci && cd ..

# lint 実行（失敗しないことを確認）
golangci-lint run ./...
```

### 動作確認シナリオ

- [x] `golangci-lint run` が node_modules の Go ファイルをスキャンせず正常終了する
- [x] `.golangci.yml` のスキーマが golangci-lint v2 で valid である（`config verify` が通る）

## テスト

- [ ] `make ci` PASS
- [x] 新規/変更コードに対するユニットテストを追加した（設定ファイルのみ、テスト不要）

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（親 issue には `Refs:`、sub-issue には `Closes:`）
- [x] README の更新が必要なら反映した（変更なし）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点

golangci-lint v1 系で使われていた `run.exclude-dirs` は v2 では無効（スキーマエラー）になった。
v2 では `linters.exclusions.paths` が正しいキーであることに注意。
