### PR TITLE
chore(go-react-spa): scaffold 後の摩擦改善 (node-version / auth 残骸 / golangci-lint)

### DIFF
--- a/.github/workflows/scaffold-verify-go-react-spa-noauth.yml
+++ b/.github/workflows/scaffold-verify-go-react-spa-noauth.yml
@@ -4,6 +4,8 @@ name: Scaffold Verify go-react-spa-noauth
 #   1. Has no auth-related source files
 #   2. Has no auth symbols in index barrels
 #   3. Compiles cleanly (TypeScript + Go)
+#   4. Passes frontend tests (Vitest) — catches import errors from any auth file
+#      left behind or newly added without updating noauth.sh
 #
 # Tested via two equivalent paths:
 #   - template=go-react-spa-noauth  (template alias)
@@ -123,6 +125,13 @@ jobs:
       - name: Install dependencies
         working-directory: /tmp/test-noauth
         run: make install
+
+      - name: Frontend tests (Vitest)
+        working-directory: /tmp/test-noauth
+        run: make test-frontend
+        # Vitest catches import errors from any auth file left behind or newly
+        # added to the template without a corresponding noauth.sh deletion.
+        # e.g. if src/api/auth.ts is re-added, any test importing authApi fails.
 
       - name: Build (TypeScript compilation + Go binary)
         working-directory: /tmp/test-noauth

--- a/.github/workflows/scaffold-verify-go-react-spa-noauth.yml
+++ b/.github/workflows/scaffold-verify-go-react-spa-noauth.yml
@@ -1,0 +1,129 @@
+name: Scaffold Verify go-react-spa-noauth
+
+# Verifies that the --no-auth scaffold transformation produces a project that:
+#   1. Has no auth-related source files
+#   2. Has no auth symbols in index barrels
+#   3. Compiles cleanly (TypeScript + Go)
+#
+# Tested via two equivalent paths:
+#   - template=go-react-spa-noauth  (template alias)
+#   - template=go-react-spa + no-auth=1  (explicit flag)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'go-react-spa/**'
+      - 'go-react-spa-noauth/**'
+      - 'react-spa/**'
+      - 'shared-react-ui/**'
+      - 'scripts/scaffold/**'
+      - '.github/workflows/scaffold-verify-go-react-spa-noauth.yml'
+  pull_request:
+    paths:
+      - 'go-react-spa/**'
+      - 'go-react-spa-noauth/**'
+      - 'react-spa/**'
+      - 'shared-react-ui/**'
+      - 'scripts/scaffold/**'
+      - '.github/workflows/scaffold-verify-go-react-spa-noauth.yml'
+
+jobs:
+  scaffold-go-react-spa-noauth:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        method:
+          - template-alias   # go-react-spa-noauth
+          - flag             # go-react-spa + no-auth=1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go-react-spa/go.mod
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: react-spa/.node-version
+
+      - name: Scaffold (template alias)
+        if: matrix.method == 'template-alias'
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=go-react-spa-noauth \
+            dest=/tmp/test-noauth \
+            name=test-noauth \
+            go-module-name=github.com/test/test-noauth
+
+      - name: Scaffold (--no-auth flag)
+        if: matrix.method == 'flag'
+        run: |
+          bash scripts/scaffold/scaffold.sh \
+            template=go-react-spa \
+            dest=/tmp/test-noauth \
+            name=test-noauth \
+            go-module-name=github.com/test/test-noauth \
+            no-auth=1
+
+      - name: Verify auth files are absent
+        run: |
+          dest=/tmp/test-noauth/frontend
+          fail=0
+          for f in \
+            src/api/auth.ts \
+            src/api/users.ts \
+            src/api/client.test.ts \
+            src/hooks/useAuthStore.ts \
+            src/hooks/useUsers.ts \
+            src/schemas/auth.ts \
+            src/schemas/user.ts \
+            src/types/auth.ts \
+            src/types/user.ts \
+            src/pages/LoginPage.tsx \
+            src/pages/UsersPage.tsx; do
+            if [ -f "$dest/$f" ]; then
+              echo "FAIL (should be absent): $f"
+              fail=1
+            else
+              echo "OK (absent): $f"
+            fi
+          done
+          exit $fail
+
+      - name: Verify index barrels contain no auth symbols
+        run: |
+          dest=/tmp/test-noauth/frontend
+          fail=0
+          check_absent() {
+            local file="$1" symbol="$2"
+            if grep -q "$symbol" "$dest/$file" 2>/dev/null; then
+              echo "FAIL: $file still references '$symbol'"
+              fail=1
+            else
+              echo "OK: $file has no '$symbol'"
+            fi
+          }
+          check_absent src/api/index.ts     authApi
+          check_absent src/api/index.ts     usersApi
+          check_absent src/api/index.ts     UNAUTHORIZED_EVENT
+          check_absent src/hooks/index.ts   useAuthStore
+          check_absent src/hooks/index.ts   useUsers
+          check_absent src/pages/index.ts   LoginPage
+          check_absent src/pages/index.ts   UsersPage
+          check_absent src/App.tsx          LoginPage
+          check_absent src/App.tsx          UNAUTHORIZED_EVENT
+          check_absent src/components/Layout.tsx  useAuthStore
+          exit $fail
+
+      - name: Install dependencies
+        working-directory: /tmp/test-noauth
+        run: make install
+
+      - name: Build (TypeScript compilation + Go binary)
+        working-directory: /tmp/test-noauth
+        run: make build

--- a/go-react-spa-noauth/README.md
+++ b/go-react-spa-noauth/README.md
@@ -1,0 +1,35 @@
+# go-react-spa-noauth
+
+Alias for `go-react-spa` with authentication removed automatically at scaffold time.
+
+JWT auth, login page, auth store, and related TypeScript files are stripped from the frontend.
+The resulting project is a Go server with an embedded React SPA that has no authentication layer.
+
+## Usage
+
+```bash
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-react-spa-noauth ~/projects/my-app
+```
+
+Equivalent to:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-react-spa ~/projects/my-app --no-auth
+```
+
+## What gets removed
+
+| Removed files | References cleaned up |
+|---|---|
+| `src/api/auth.ts`, `users.ts`, `users.test.ts` | `src/api/index.ts` re-exports |
+| `src/api/client.test.ts` | auth-specific test cases |
+| `src/hooks/useAuthStore.ts`, `useUsers.ts`, `useUsers.test.tsx` | `src/hooks/index.ts` re-exports |
+| `src/schemas/auth.ts`, `user.ts` | `src/schemas/index.ts` exports |
+| `src/types/auth.ts`, `user.ts` | `src/types/index.ts` exports |
+| `src/pages/LoginPage.tsx`, `LoginPage.test.tsx` | `src/pages/index.ts`, `App.tsx` routes |
+| `src/pages/UsersPage.tsx`, `UsersPage.test.tsx` | `App.tsx` routes |
+
+`Layout.tsx`, `App.tsx`, `App.test.tsx`, and `Layout.test.tsx` are rewritten to remove auth UI.
+`src/api/client.ts` is rewritten to remove Bearer-token and 401-redirect logic.

--- a/go-react-spa/.golangci.yml
+++ b/go-react-spa/.golangci.yml
@@ -1,6 +1,34 @@
 version: "2"
 
 linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - unconvert
+    - unparam
+  settings:
+    errcheck:
+      check-type-assertions: true
+    govet:
+      enable-all: true
   exclusions:
     paths:
       - frontend/node_modules
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - go-react-spa
+
+run:
+  timeout: 5m
+  exclude-dirs:
+    - frontend/node_modules

--- a/go-react-spa/README.md
+++ b/go-react-spa/README.md
@@ -158,3 +158,31 @@ If the project will be published, after scaffolding run:
 ```bash
 go mod edit -module github.com/<user>/<repo>
 ```
+
+## Removing authentication
+
+If your project does not need JWT authentication, scaffold without it:
+
+```bash
+# Option A: dedicated no-auth template
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-react-spa-noauth ~/projects/my-app
+
+# Option B: --no-auth flag on go-react-spa
+curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
+  | sh -s -- go-react-spa ~/projects/my-app --no-auth
+```
+
+Both options remove the following frontend files and clean up their index re-exports:
+
+| Removed | Cleaned up |
+|---|---|
+| `src/api/auth.ts`, `users.ts`, `users.test.ts` | `src/api/index.ts` |
+| `src/api/client.test.ts` | auth-specific tests |
+| `src/hooks/useAuthStore.ts`, `useUsers.ts`, `useUsers.test.tsx` | `src/hooks/index.ts` |
+| `src/schemas/auth.ts`, `user.ts` | `src/schemas/index.ts` |
+| `src/types/auth.ts`, `user.ts` | `src/types/index.ts` |
+| `src/pages/LoginPage.tsx`, `LoginPage.test.tsx`, `UsersPage.tsx`, `UsersPage.test.tsx` | `App.tsx`, `src/pages/index.ts` |
+
+`Layout.tsx`, `App.tsx`, and their tests are rewritten to remove auth UI and routes.
+`src/api/client.ts` is rewritten to remove Bearer-token injection and 401-redirect logic.

--- a/go-react-spa/cmd/server/main.go
+++ b/go-react-spa/cmd/server/main.go
@@ -26,9 +26,9 @@ import (
 
 type Config struct {
 	Port            string        `env:"PORT,default=8080"`
-	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT,default=10s"`
 	DatabaseDSN     string        `env:"DATABASE_DSN,default=app.db"`
 	JWTSecret       string        `env:"JWT_SECRET,default=change-me-in-production"`
+	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT,default=10s"`
 	JWTTTL          time.Duration `env:"JWT_TTL,default=24h"`
 }
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -67,7 +67,7 @@ die() {
 
 usage() {
   cat <<'EOF'
-Usage: download.sh <template> <dest> [--name=NAME] [--no-github-templates]
+Usage: download.sh <template> <dest> [--name=NAME] [--no-github-templates] [--no-auth]
 
 See https://github.com/rengotaku/my-boilerplate#usage for full documentation.
 Run with an unknown <template> to see the currently available list.
@@ -78,6 +78,7 @@ template=""
 dest=""
 name=""
 no_github_templates=""
+no_auth=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -87,6 +88,7 @@ while [ $# -gt 0 ]; do
       ;;
     --name=*) name="${1#--name=}" ;;
     --no-github-templates) no_github_templates="1" ;;
+    --no-auth) no_auth="1" ;;
     --*) die "Unknown option: $1 (see --help)" ;;
     *)
       if [ -z "$template" ]; then
@@ -171,10 +173,11 @@ fi
 # `.compose.toml`, e.g. go-react-spa) read sibling templates from $extracted
 # during scaffolding, so the full tarball must remain available — do not
 # pre-trim it down to $extracted/$template here.
-info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module})"
+info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module}${no_auth:+ no-auth})"
 scaffold_args="template=$template dest=$dest name=$name"
 [ -n "$module" ] && scaffold_args="$scaffold_args go-module-name=$module"
 [ -n "$no_github_templates" ] && scaffold_args="$scaffold_args no-github-templates=1"
+[ -n "$no_auth" ] && scaffold_args="$scaffold_args no-auth=1"
 # shellcheck disable=SC2086
 bash "$extracted/scripts/scaffold/scaffold.sh" $scaffold_args
 

--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -11,6 +11,7 @@ VALID_TEMPLATES=(
   go-ssr-web
   go-ssr-web-minimal
   go-react-spa
+  go-react-spa-noauth
   go-cli
   react-spa
   react-spa-graphql
@@ -142,6 +143,40 @@ validate_module() {
   if [[ ! "$module" =~ ^[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)*$ ]]; then
     die "Invalid module path: $module"
   fi
+}
+
+# Resolve a bare major Node.js version in .node-version / .nvmrc to a full
+# patch version (e.g. "22" -> "22.15.0"). Tries nodenv first, then falls back
+# to the currently active `node` binary if the major matches. Leaves the file
+# unchanged and emits a warning when neither source is available.
+resolve_node_version_files() {
+  local dir="$1"
+  local f ver resolved cur_ver
+  for f in "$dir/.node-version" "$dir/.nvmrc"; do
+    [[ -f "$f" ]] || continue
+    ver=$(tr -d '[:space:]' < "$f")
+    # Only process bare major versions like "22"
+    [[ "$ver" =~ ^[0-9]+$ ]] || continue
+    resolved=""
+    if command -v nodenv >/dev/null 2>&1; then
+      resolved=$(nodenv install --list 2>/dev/null \
+        | grep -E "^[[:space:]]+${ver}\.[0-9]+\.[0-9]+$" \
+        | tail -1 \
+        | tr -d '[:space:]' || true)
+    fi
+    if [[ -z "$resolved" ]] && command -v node >/dev/null 2>&1; then
+      cur_ver=$(node --version 2>/dev/null | tr -d 'v' || true)
+      if [[ "$cur_ver" =~ ^${ver}\. ]]; then
+        resolved="$cur_ver"
+      fi
+    fi
+    if [[ -n "$resolved" ]]; then
+      info "[node-version] $(basename "$f"): $ver -> $resolved"
+      printf '%s\n' "$resolved" > "$f"
+    else
+      warn "[node-version] cannot resolve Node.js $ver to a full version in $(basename "$f"); leaving as-is"
+    fi
+  done
 }
 
 # Copy template and remove build artifacts

--- a/scripts/scaffold/lib/noauth.sh
+++ b/scripts/scaffold/lib/noauth.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# No-auth transformation.
+#
+# Removes authentication-related files and rewrites index barrels, App.tsx,
+# Layout.tsx, and client.ts so the scaffolded project compiles without auth.
+#
+# Usage:
+#   apply_noauth <frontend_dir>
+#
+# <frontend_dir> is the root of the React source tree:
+#   - go-react-spa:  $dest/frontend
+#   - react-spa:     $dest
+
+apply_noauth() {
+  local fdir="$1"
+
+  info "[no-auth] Removing auth files..."
+  rm -f \
+    "$fdir/src/api/auth.ts" \
+    "$fdir/src/api/users.ts" \
+    "$fdir/src/api/users.test.ts" \
+    "$fdir/src/api/client.test.ts" \
+    "$fdir/src/hooks/useAuthStore.ts" \
+    "$fdir/src/hooks/useUsers.ts" \
+    "$fdir/src/hooks/useUsers.test.tsx" \
+    "$fdir/src/schemas/auth.ts" \
+    "$fdir/src/schemas/user.ts" \
+    "$fdir/src/types/auth.ts" \
+    "$fdir/src/types/user.ts" \
+    "$fdir/src/pages/LoginPage.tsx" \
+    "$fdir/src/pages/LoginPage.test.tsx" \
+    "$fdir/src/pages/UsersPage.tsx" \
+    "$fdir/src/pages/UsersPage.test.tsx"
+
+  info "[no-auth] Rewriting index files and core modules..."
+
+  cat > "$fdir/src/api/index.ts" << 'NOAUTH_EOF'
+export { apiClient } from "./client";
+NOAUTH_EOF
+
+  cat > "$fdir/src/api/client.ts" << 'NOAUTH_EOF'
+import ky from "ky";
+import { logger } from "../lib/logger";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080";
+
+export const apiClient = ky.create({
+  prefixUrl: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  hooks: {
+    beforeError: [
+      async (error) => {
+        const { response } = error;
+        if (response) {
+          try {
+            const body = await response.json();
+            const message =
+              (body as { message?: string; error?: string }).message ||
+              (body as { error?: string }).error ||
+              error.message;
+            logger.error(`API ${response.url} failed: ${response.status}`, message);
+            error.message = message;
+          } catch {
+            logger.warn(`Failed to parse error response: ${response.url}`);
+          }
+        } else {
+          logger.error("Network request failed", error.message);
+        }
+        return error;
+      },
+    ],
+  },
+});
+NOAUTH_EOF
+
+  cat > "$fdir/src/hooks/index.ts" << 'NOAUTH_EOF'
+export { useUIStore } from "./useUIStore";
+NOAUTH_EOF
+
+  cat > "$fdir/src/schemas/index.ts" << 'NOAUTH_EOF'
+NOAUTH_EOF
+
+  cat > "$fdir/src/types/index.ts" << 'NOAUTH_EOF'
+NOAUTH_EOF
+
+  cat > "$fdir/src/pages/index.ts" << 'NOAUTH_EOF'
+export { HomePage } from "./HomePage";
+export { NotFoundPage } from "./NotFoundPage";
+NOAUTH_EOF
+
+  cat > "$fdir/src/components/Layout.tsx" << 'NOAUTH_EOF'
+import { Outlet, NavLink } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+    isActive
+      ? "bg-primary-foreground/15 text-primary-foreground"
+      : "text-primary-foreground/80 hover:bg-primary-foreground/10 hover:text-primary-foreground"
+  );
+
+export function Layout() {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="bg-primary text-primary-foreground shadow">
+        <div className="mx-auto flex h-14 max-w-5xl items-center px-4">
+          <span className="mr-6 text-lg font-semibold">React SPA</span>
+          <nav className="flex items-center gap-1">
+            <NavLink to="/" end className={navLinkClass}>
+              Home
+            </NavLink>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+NOAUTH_EOF
+
+  cat > "$fdir/src/components/Layout.test.tsx" << 'NOAUTH_EOF'
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { Layout } from "./Layout";
+
+describe("Layout", () => {
+  it("renders navigation links", () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+  });
+
+  it("renders header and main sections", () => {
+    render(
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+});
+NOAUTH_EOF
+
+  cat > "$fdir/src/App.tsx" << 'NOAUTH_EOF'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Layout } from "@/components";
+import { HomePage, NotFoundPage } from "@/pages";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+    },
+  },
+});
+
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+export default App;
+NOAUTH_EOF
+
+  cat > "$fdir/src/App.test.tsx" << 'NOAUTH_EOF'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import App from "./App";
+
+describe("App", () => {
+  it("renders home page by default", () => {
+    render(<App />);
+    expect(screen.getByText("React SPA Boilerplate")).toBeInTheDocument();
+  });
+
+  it("shows navigation links", () => {
+    render(<App />);
+    expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+  });
+});
+NOAUTH_EOF
+
+  info "[no-auth] Done."
+}

--- a/scripts/scaffold/lib/react.sh
+++ b/scripts/scaffold/lib/react.sh
@@ -22,4 +22,6 @@ apply_react_replacements() {
     sed_inplace "s|^name = \"${template}\"|name = \"${name}\"|" "$dest/wrangler.toml"
     info "Updated wrangler.toml name"
   fi
+
+  resolve_node_version_files "$dest"
 }

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -21,6 +21,7 @@ dest=""
 name=""
 module=""
 no_github_templates=""
+no_auth=""
 
 for arg in "$@"; do
   case "$arg" in
@@ -29,9 +30,17 @@ for arg in "$@"; do
     name=*) name="${arg#name=}" ;;
     go-module-name=*) module="${arg#go-module-name=}" ;;
     no-github-templates=*) no_github_templates="${arg#no-github-templates=}" ;;
+    no-auth=*) no_auth="${arg#no-auth=}" ;;
     *) die "Unknown argument: $arg" ;;
   esac
 done
+
+# --- Template aliases ---
+# go-react-spa-noauth is a virtual template: same as go-react-spa with no-auth applied.
+if [[ "$template" == "go-react-spa-noauth" ]]; then
+  template="go-react-spa"
+  no_auth="1"
+fi
 
 # --- Validation ---
 [[ -z "$template" ]] && die "Missing required argument: template="
@@ -83,6 +92,11 @@ if [[ -f "$dest/frontend/.shared-ui.toml" ]]; then
   merge_shared_ui "$dest/frontend" "$REPO_ROOT"
 fi
 
+# --- Node version resolution (go-react-spa: frontend/ was materialized above) ---
+if [[ -d "$dest/frontend" ]]; then
+  resolve_node_version_files "$dest/frontend"
+fi
+
 # --- CI workflow transformation (before family replacements so they can process CI files too) ---
 info "Transforming CI workflows..."
 source "$SCRIPT_DIR/lib/ci.sh"
@@ -118,6 +132,17 @@ case "$family" in
     apply_rust_replacements "$dest" "$template" "$name"
     ;;
 esac
+
+# --- No-auth transformation ---
+if [[ -n "$no_auth" && "$no_auth" != "0" ]]; then
+  # shellcheck source=lib/noauth.sh
+  source "$SCRIPT_DIR/lib/noauth.sh"
+  if [[ -d "$dest/frontend" ]]; then
+    apply_noauth "$dest/frontend"
+  else
+    apply_noauth "$dest"
+  fi
+fi
 
 # --- GitHub workflow templates injection ---
 # Skip if: caller passed no-github-templates=1, OR the source template already ships .github/
@@ -160,6 +185,14 @@ case "$family" in
       echo "  make install"
       echo "  make build"
       echo "  ./bin/server"
+      if [[ -z "$no_auth" || "$no_auth" == "0" ]]; then
+        echo ""
+        echo "Auth not needed? Remove it at scaffold time:"
+        echo "  Use template go-react-spa-noauth, or add --no-auth to the download command."
+        echo "  Manual removal: delete src/api/auth.ts users.ts, src/hooks/useAuthStore.ts,"
+        echo "  src/pages/LoginPage.tsx, src/schemas/auth.ts user.ts, src/types/auth.ts user.ts"
+        echo "  then clean up the re-exports in the corresponding index.ts files."
+      fi
     else
       echo "  go mod tidy"
       echo "  make ci"


### PR DESCRIPTION
## 概要

`go-react-spa` テンプレートを scaffold する際に遭遇した3つの摩擦を修正する。
node-version の prefix マッチ問題、auth 残骸による TypeScript エラー、golangci-lint が `node_modules` 内の Go ファイルを拾う問題を解消する。

## 関連 Issue

Refs: #206

## Affects

なし

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [x] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

```bash
# Issue #1: node-version 解決（nodenv または現行 node が一致する場合に full version を書き込む）
bash scripts/scaffold/scaffold.sh template=go-react-spa dest=/tmp/test-node-ver name=testapp go-module-name=testapp
cat /tmp/test-node-ver/frontend/.node-version  # nodenv 環境では "22.x.x" に解決される

# Issue #2A: go-react-spa-noauth テンプレートエイリアス
bash scripts/scaffold/scaffold.sh template=go-react-spa-noauth dest=/tmp/test-noauth name=myapp go-module-name=myapp
ls /tmp/test-noauth/frontend/src/api/         # client.ts index.ts のみ (auth.ts なし)
cat /tmp/test-noauth/frontend/src/App.tsx     # LoginPage route なし

# Issue #2B: --no-auth フラグ
bash scripts/scaffold/scaffold.sh template=go-react-spa dest=/tmp/test-flag name=myapp go-module-name=myapp no-auth=1
ls /tmp/test-flag/frontend/src/hooks/         # useUIStore のみ (useAuthStore なし)

# Issue #3: golangci-lint が frontend/node_modules を無視
cat go-react-spa/.golangci.yml | grep exclude-dirs -A2
```

### 動作確認シナリオ

- [x] `go-react-spa-noauth` scaffold 後に auth 関連ファイルが存在しないことを確認
- [x] `--no-auth` フラグで同様の変換が適用されることを確認
- [x] `.golangci.yml` に `exclude-dirs: [frontend/node_modules]` が含まれていることを確認
- [x] `react-spa` に `--no-auth` を適用しても同様に動作することを確認

## テスト

- [ ] `make ci` PASS
- [x] scaffold smoke test で各ケースの出力を手動確認済み

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（親 issue には `Refs:`、sub-issue には `Closes:`）
- [x] README の更新が必要なら反映した（`go-react-spa/README.md` に no-auth 手順を追記）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点

**Issue #1 (node-version):** scaffold 時に `nodenv install --list` → `node --version` の順で解決を試みる。どちらも使えない場合は `22` のまま警告を出す（scaffold を失敗させない設計）。

**Issue #2 (auth 残骸):** 3 つのアプローチを全て実装:
- A: `go-react-spa-noauth` テンプレートエイリアス（scaffold.sh 内で `go-react-spa` + `no_auth=1` に解決）
- B: `--no-auth` フラグ（`download.sh` / `scaffold.sh` 両方に追加）
- C: `go-react-spa/README.md` に手動削除手順と `--no-auth` の案内を追記

`noauth.sh` は `apply_noauth(frontend_dir)` 関数で実装しており、`go-react-spa`（`$dest/frontend/`）と `react-spa`（`$dest/`）の両方に対応する。

**Issue #3 (golangci-lint):** `.golangci.yml` の `run.exclude-dirs` で `frontend/node_modules` を除外。`go.sh` の既存ロジックにより `local-prefixes` はプロジェクト名に自動置換される。
