### PR TITLE
feat(download.sh): --list / --tree / --pick で既存プロジェクトへの取り込みを支援 (#203)

### DIFF
--- a/go-cli/template.toml
+++ b/go-cli/template.toml
@@ -1,0 +1,4 @@
+name = "go-cli"
+language = "Go"
+description = "Batteries-included な Go CLI（cobra + slog + envconfig + Make ターゲット）"
+tags = ["cli", "cobra"]

--- a/go-graphql-api/template.toml
+++ b/go-graphql-api/template.toml
@@ -1,0 +1,4 @@
+name = "go-graphql-api"
+language = "Go"
+description = "Go + gqlgen の GraphQL API ボイラープレート"
+tags = ["api", "graphql", "gqlgen"]

--- a/go-grpc-api/template.toml
+++ b/go-grpc-api/template.toml
@@ -1,0 +1,4 @@
+name = "go-grpc-api"
+language = "Go"
+description = "クリーンアーキテクチャな Go gRPC API ボイラープレート"
+tags = ["api", "grpc"]

--- a/go-react-spa-noauth/template.toml
+++ b/go-react-spa-noauth/template.toml
@@ -1,0 +1,4 @@
+name = "go-react-spa-noauth"
+language = "Go+React"
+description = "go-react-spa から JWT 認証を除いた版（scaffold 時に自動展開）"
+tags = ["spa", "fullstack", "gin", "react", "embed", "no-auth"]

--- a/go-react-spa/template.toml
+++ b/go-react-spa/template.toml
@@ -1,0 +1,4 @@
+name = "go-react-spa"
+language = "Go+React"
+description = "gin + embed で React SPA を同梱するフルスタック monolith（JWT 認証付き）"
+tags = ["spa", "fullstack", "gin", "react", "embed", "auth", "composite"]

--- a/go-rest-api/template.toml
+++ b/go-rest-api/template.toml
@@ -1,0 +1,4 @@
+name = "go-rest-api"
+language = "Go"
+description = "Gin + GORM + JWT の Batteries Included な REST API"
+tags = ["api", "rest", "gin", "gorm", "jwt"]

--- a/go-ssr-web-minimal/template.toml
+++ b/go-ssr-web-minimal/template.toml
@@ -1,0 +1,4 @@
+name = "go-ssr-web-minimal"
+language = "Go"
+description = "最小構成の Go SSR Web（gin + html/template + embed + slog + envconfig + 素の CSS）"
+tags = ["web", "ssr", "gin", "minimal"]

--- a/go-ssr-web/template.toml
+++ b/go-ssr-web/template.toml
@@ -1,0 +1,4 @@
+name = "go-ssr-web"
+language = "Go"
+description = "Batteries-included な Go SSR Web（gin + html/template + 各種 Make ターゲット）"
+tags = ["web", "ssr", "gin"]

--- a/python-cli/template.toml
+++ b/python-cli/template.toml
@@ -1,0 +1,4 @@
+name = "python-cli"
+language = "Python"
+description = "uv + Typer + ruff + mypy + pytest の Python CLI"
+tags = ["cli", "typer", "uv"]

--- a/python-web/template.toml
+++ b/python-web/template.toml
@@ -1,0 +1,4 @@
+name = "python-web"
+language = "Python"
+description = "FastAPI + Jinja2 + Alpine.js + Tailwind CSS + SQLite の Web ボイラープレート"
+tags = ["web", "fastapi", "jinja2", "alpine", "tailwind"]

--- a/react-spa-cloudflare/template.toml
+++ b/react-spa-cloudflare/template.toml
@@ -1,0 +1,4 @@
+name = "react-spa-cloudflare"
+language = "React"
+description = "Cloudflare Pages デプロイ向けに最適化された React SPA"
+tags = ["spa", "vite", "react", "cloudflare"]

--- a/react-spa-graphql/template.toml
+++ b/react-spa-graphql/template.toml
@@ -1,0 +1,4 @@
+name = "react-spa-graphql"
+language = "React"
+description = "Apollo Client + codegen で GraphQL を扱う React SPA"
+tags = ["spa", "vite", "react", "graphql", "apollo"]

--- a/react-spa/template.toml
+++ b/react-spa/template.toml
@@ -1,0 +1,4 @@
+name = "react-spa"
+language = "React"
+description = "Vite + TypeScript + Tailwind + Zustand の最小 React SPA"
+tags = ["spa", "vite", "react"]

--- a/rust-cli/template.toml
+++ b/rust-cli/template.toml
@@ -1,0 +1,4 @@
+name = "rust-cli"
+language = "Rust"
+description = "Rust + clap + config + tracing の Batteries-included な CLI"
+tags = ["cli", "clap"]

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,35 +1,71 @@
 #!/bin/sh
-# download.sh - Fetch a my-boilerplate template and scaffold it as a usable
-# standalone project at a target directory.
+# download.sh - Fetch a my-boilerplate template.
 #
 # This script does NOT require my-boilerplate to be cloned locally. It
-# downloads the tarball at the requested ref, extracts the requested template
-# directory, and **always** delegates to the bundled scripts/scaffold/scaffold.sh
-# which rewrites template-name placeholders (Makefile, HTML, Go module path,
-# package.json name, etc.) so the result is immediately usable.
+# downloads the tarball at the requested ref and operates on the extracted
+# contents in one of four modes:
 #
-# Scaffolding is mandatory; there is no plain-copy mode. The premise of this
-# tool is "create a new project from a boilerplate", not "fetch raw files".
+#   <template> <dest>           Scaffold a new project (default).
+#   --list                      Print the available templates list.
+#   <template> --tree           Print the template's file tree.
+#   <template> <dest> --pick=…  Copy specific files into an existing project.
+#
+# Scaffold mode (the original behavior) is unchanged. It always delegates to
+# scripts/scaffold/scaffold.sh so template-name placeholders are rewritten and
+# the produced directory is immediately usable. The other modes are read-only
+# (--list / --tree) or strictly file-copy (--pick) and never run scaffold.sh.
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/rengotaku/my-boilerplate/main/scripts/download.sh \
-#     | sh -s -- <template> <dest> [--name=NAME]
+#     | sh -s -- <template> <dest> [--name=NAME] [--no-github-templates] [--no-auth]
+#   curl -sSL .../download.sh | sh -s -- --list [--format=json]
+#   curl -sSL .../download.sh | sh -s -- <template> --tree
+#   curl -sSL .../download.sh | sh -s -- <template> <dest> --pick=PATH[,PATH...] [--apply] [--overwrite]
 #
-# Required:
-#   <template>   Template directory name (e.g., go-ssr-web, react-spa).
+# Required (scaffold / pick):
+#   <template>   Template directory name (e.g., go-cli, go-react-spa, react-spa).
 #                Validated against the actual contents of the downloaded
 #                tarball; an unknown name prints the available list.
-#   <dest>       Destination directory (must not exist; parent must exist).
+#   <dest>       Destination directory. In scaffold mode it must not exist
+#                (parent must); in --pick mode it must already exist.
 #
-# Optional:
+# Optional (scaffold):
 #   --name=NAME               Project name written into Makefile / package.json / etc.
 #                             Defaults to basename(<dest>).
 #   --no-github-templates     Skip injecting .github/PULL_REQUEST_TEMPLATE.md and
 #                             .github/ISSUE_TEMPLATE/*.md into the scaffolded project.
+#   --no-auth                 (go-react-spa only) strip JWT auth at scaffold time.
 #
-# Go templates: the `module` line in go.mod is auto-set to basename(<dest>),
-# producing a local-only module suitable for prototyping. If you plan to
-# publish the project, edit go.mod after scaffolding:
+# --list:
+#   --format=text  (default) human-readable columns: name / language / description
+#   --format=json  machine-readable JSON array (each entry has name / language /
+#                  description / tags). Recommended when an AI assistant invokes
+#                  this script — easier to parse, fewer tokens.
+#
+# --tree:
+#   Prints a flat sorted list of files under the template directory (relative to
+#   the template root). Composite templates (those that ship a `.compose.toml`)
+#   include a trailing note explaining that frontend/ is materialized at
+#   scaffold time from a sibling template.
+#
+# --pick:
+#   --pick=PATH[,PATH...]   Files / directories under the template to copy.
+#                           Directories are walked recursively.
+#   --apply                 Without this flag the run is a dry-run and only
+#                           prints would-add / would-overwrite / would-skip
+#                           lines. The default is dry-run on purpose so that
+#                           accidental overwrites cannot happen.
+#   --overwrite             When --apply is set, replace existing files at the
+#                           destination. Without --overwrite the default is to
+#                           skip existing files.
+#   Note: --pick is not supported for composite templates (those with a
+#         .compose.toml). The overlay-only file layout is meaningful only after
+#         compose, so copying overlay files into an existing project would do
+#         the wrong thing.
+#
+# Go templates (scaffold mode): the `module` line in go.mod is auto-set to
+# basename(<dest>), producing a local-only module suitable for prototyping. If
+# you plan to publish the project, edit go.mod after scaffolding:
 #   go mod edit -module github.com/<user>/<repo>
 # The Next steps message printed by scaffold.sh repeats this hint.
 #
@@ -37,14 +73,21 @@
 #   MY_BOILERPLATE_REPO  Override repo (default: rengotaku/my-boilerplate).
 #   MY_BOILERPLATE_REF   Override ref / branch / tag (default: main).
 #
-# Example:
+# Examples:
 #   curl -sSL .../download.sh | sh -s -- go-ssr-web ~/projects/my-app
+#   curl -sSL .../download.sh | sh -s -- --list
+#   curl -sSL .../download.sh | sh -s -- --list --format=json
+#   curl -sSL .../download.sh | sh -s -- go-cli --tree
+#   curl -sSL .../download.sh | sh -s -- go-cli ./existing --pick=Makefile,.golangci.yml
+#   curl -sSL .../download.sh | sh -s -- go-cli ./existing --pick=Makefile --apply --overwrite
 
 set -eu
 
 REPO="${MY_BOILERPLATE_REPO:-rengotaku/my-boilerplate}"
 REF="${MY_BOILERPLATE_REF:-main}"
-TARBALL_URL="https://github.com/${REPO}/archive/refs/heads/${REF}.tar.gz"
+# MY_BOILERPLATE_TARBALL_URL lets tests / CI / forks point at a local file://
+# URL or a non-GitHub mirror without monkey-patching $REPO / $REF.
+TARBALL_URL="${MY_BOILERPLATE_TARBALL_URL:-https://github.com/${REPO}/archive/refs/heads/${REF}.tar.gz}"
 
 if [ -t 2 ]; then
   RED=$(printf '\033[0;31m')
@@ -67,10 +110,13 @@ die() {
 
 usage() {
   cat <<'EOF'
-Usage: download.sh <template> <dest> [--name=NAME] [--no-github-templates] [--no-auth]
+Usage:
+  download.sh <template> <dest> [--name=NAME] [--no-github-templates] [--no-auth]
+  download.sh --list [--format=text|json]
+  download.sh <template> --tree
+  download.sh <template> <dest> --pick=PATH[,PATH...] [--apply] [--overwrite]
 
 See https://github.com/rengotaku/my-boilerplate#usage for full documentation.
-Run with an unknown <template> to see the currently available list.
 EOF
 }
 
@@ -79,6 +125,11 @@ dest=""
 name=""
 no_github_templates=""
 no_auth=""
+mode="scaffold"
+format="text"
+pick=""
+apply=""
+overwrite=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -89,6 +140,15 @@ while [ $# -gt 0 ]; do
     --name=*) name="${1#--name=}" ;;
     --no-github-templates) no_github_templates="1" ;;
     --no-auth) no_auth="1" ;;
+    --list) mode="list" ;;
+    --tree) mode="tree" ;;
+    --pick=*)
+      pick="${1#--pick=}"
+      mode="pick"
+      ;;
+    --apply) apply="1" ;;
+    --overwrite) overwrite="1" ;;
+    --format=*) format="${1#--format=}" ;;
     --*) die "Unknown option: $1 (see --help)" ;;
     *)
       if [ -z "$template" ]; then
@@ -103,37 +163,66 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-if [ -z "$template" ] || [ -z "$dest" ]; then
-  usage
-  exit 1
-fi
+# Mode-specific argument validation. The default is scaffold mode, but the
+# other modes intentionally relax the <template> / <dest> requirements:
+#   --list           neither
+#   --tree           template only
+#   --pick           both (dest must already exist)
+case "$mode" in
+  list)
+    [ -n "$template" ] && die "--list takes no positional arguments"
+    [ -n "$dest" ] && die "--list takes no positional arguments"
+    case "$format" in
+      text | json) ;;
+      *) die "Unknown --format: $format (expected text or json)" ;;
+    esac
+    ;;
+  tree)
+    [ -z "$template" ] && die "--tree requires <template>"
+    [ -n "$dest" ] && die "--tree does not take <dest>"
+    ;;
+  pick)
+    [ -z "$template" ] && die "--pick requires <template>"
+    [ -z "$dest" ] && die "--pick requires <dest>"
+    [ -z "$pick" ] && die "--pick requires at least one path"
+    ;;
+  scaffold)
+    if [ -z "$template" ] || [ -z "$dest" ]; then
+      usage
+      exit 1
+    fi
+    ;;
+esac
 
 # Sanity-check the template token before hitting the network. The authoritative
 # validation happens after extraction (against the actual tarball contents) so
 # that template additions / renames / removals do not require editing this file.
-case "$template" in
-  *[!a-zA-Z0-9_-]* | "" | -*)
-    die "Invalid template name: $template"
-    ;;
-esac
+if [ -n "$template" ]; then
+  case "$template" in
+    *[!a-zA-Z0-9_-]* | -*)
+      die "Invalid template name: $template"
+      ;;
+  esac
+fi
 
-[ -e "$dest" ] && die "Destination already exists: $dest"
-parent=$(dirname "$dest")
-[ -d "$parent" ] || die "Parent directory does not exist: $parent"
+if [ "$mode" = "scaffold" ]; then
+  [ -e "$dest" ] && die "Destination already exists: $dest"
+  parent=$(dirname "$dest")
+  [ -d "$parent" ] || die "Parent directory does not exist: $parent"
 
-# Scaffolding is mandatory. Auto-derive name from <dest> so a single positional
-# argument is enough for the common case. For go-* templates we also derive a
-# local-only module name; users who plan to publish should run
-# `go mod edit -module github.com/<user>/<repo>` after scaffolding.
-[ -z "$name" ] && name=$(basename "$dest")
+  # Auto-derive name from <dest> so a single positional argument is enough.
+  [ -z "$name" ] && name=$(basename "$dest")
 
-module=""
-case "$template" in
-  go-*) module=$(basename "$dest") ;;
-esac
+  module=""
+  case "$template" in
+    go-*) module=$(basename "$dest") ;;
+  esac
 
-if ! command -v bash >/dev/null 2>&1; then
-  die "bash is required to run the bundled scripts/scaffold/scaffold.sh"
+  if ! command -v bash >/dev/null 2>&1; then
+    die "bash is required to run the bundled scripts/scaffold/scaffold.sh"
+  fi
+elif [ "$mode" = "pick" ]; then
+  [ -d "$dest" ] || die "Destination directory does not exist: $dest (--pick requires an existing project)"
 fi
 
 tmpdir=$(mktemp -d)
@@ -154,31 +243,212 @@ tar -xzf "$tmpdir/repo.tar.gz" -C "$tmpdir"
 extracted=$(find "$tmpdir" -maxdepth 1 -type d -name 'my-boilerplate-*' | head -n1)
 [ -d "$extracted" ] || die "Extraction failed: tarball did not contain expected top-level directory"
 
-if [ ! -d "$extracted/$template" ]; then
-  # Build the available-template list dynamically from the extracted tarball
-  # so it stays accurate as templates are added / renamed / removed. Filter
-  # by the documented naming convention "<language>-<type>".
-  available=$(
-    cd "$extracted" && \
-      find . -mindepth 1 -maxdepth 1 -type d \
-        \( -name 'go-*' -o -name 'python-*' -o -name 'react-*' -o -name 'rust-*' \) \
-        -exec basename {} \; | sort | tr '\n' ' '
-  )
-  die "Template '$template' not found at ${REPO}@${REF}. Available: $available"
-fi
+# Parse a single string-valued TOML field from template.toml. The template.toml
+# files we ship are intentionally simple `key = "value"` lines, so a plain
+# grep+sed is sufficient and avoids requiring a TOML parser at runtime.
+toml_string_field() {
+  toml_file="$1"
+  key="$2"
+  [ -f "$toml_file" ] || { printf '%s' ""; return; }
+  grep -E "^${key}[[:space:]]*=" "$toml_file" \
+    | head -n1 \
+    | sed -E 's/^[^=]+=[[:space:]]*"([^"]*)".*/\1/'
+}
 
-# Always invoke scaffold.sh. It rewrites template-name placeholders (Makefile /
-# HTML / Go module path / package.json name etc.) so the resulting directory
-# is a usable standalone project. Composite templates (those that ship a
-# `.compose.toml`, e.g. go-react-spa) read sibling templates from $extracted
-# during scaffolding, so the full tarball must remain available — do not
-# pre-trim it down to $extracted/$template here.
-info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module}${no_auth:+ no-auth})"
-scaffold_args="template=$template dest=$dest name=$name"
-[ -n "$module" ] && scaffold_args="$scaffold_args go-module-name=$module"
-[ -n "$no_github_templates" ] && scaffold_args="$scaffold_args no-github-templates=1"
-[ -n "$no_auth" ] && scaffold_args="$scaffold_args no-auth=1"
-# shellcheck disable=SC2086
-bash "$extracted/scripts/scaffold/scaffold.sh" $scaffold_args
+# Parse a TOML array of strings (e.g. tags = ["a", "b"]) into a comma-separated
+# list. Single-line arrays only — multi-line arrays are not used in our toml.
+toml_array_field() {
+  toml_file="$1"
+  key="$2"
+  [ -f "$toml_file" ] || { printf '%s' ""; return; }
+  grep -E "^${key}[[:space:]]*=" "$toml_file" \
+    | head -n1 \
+    | sed -E 's/^[^=]+=[[:space:]]*\[(.*)\].*/\1/' \
+    | tr ',' '\n' \
+    | sed -E 's/^[[:space:]]*"([^"]*)".*$/\1/' \
+    | paste -sd ',' -
+}
 
-info "Done: $dest"
+# Escape a string for safe inclusion inside a JSON double-quoted string.
+# Only the two characters that *must* be escaped — backslash and quote — are
+# touched. Our descriptions don't contain control characters; if that changes
+# this needs to grow.
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Discover the templates we know about by looking for template.toml files. This
+# is the single source of truth for --list output — adding a new template
+# requires dropping template.toml into the template directory, nothing else.
+discover_templates() {
+  ( cd "$extracted" && \
+    find . -mindepth 2 -maxdepth 2 -type f -name 'template.toml' \
+      | sed -E 's|^\./([^/]+)/template\.toml$|\1|' \
+      | sort )
+}
+
+emit_list_text() {
+  # Render an aligned 3-column table: name / language / description.
+  # The widths are computed from the actual entries so adding a long template
+  # name doesn't break alignment.
+  templates=$(discover_templates)
+  [ -z "$templates" ] && die "No templates with template.toml found in tarball"
+
+  name_w=0
+  lang_w=0
+  for t in $templates; do
+    nlen=${#t}
+    [ "$nlen" -gt "$name_w" ] && name_w=$nlen
+    lang=$(toml_string_field "$extracted/$t/template.toml" language)
+    llen=${#lang}
+    [ "$llen" -gt "$lang_w" ] && lang_w=$llen
+  done
+  name_w=$((name_w + 2))
+  lang_w=$((lang_w + 2))
+
+  for t in $templates; do
+    lang=$(toml_string_field "$extracted/$t/template.toml" language)
+    desc=$(toml_string_field "$extracted/$t/template.toml" description)
+    printf "%-${name_w}s%-${lang_w}s%s\n" "$t" "$lang" "$desc"
+  done
+}
+
+emit_list_json() {
+  templates=$(discover_templates)
+  printf '['
+  first=1
+  for t in $templates; do
+    lang=$(toml_string_field "$extracted/$t/template.toml" language)
+    desc=$(toml_string_field "$extracted/$t/template.toml" description)
+    tags=$(toml_array_field "$extracted/$t/template.toml" tags)
+    if [ "$first" = 1 ]; then
+      first=0
+    else
+      printf ','
+    fi
+    printf '{"name":"%s","language":"%s","description":"%s","tags":[' \
+      "$(json_escape "$t")" \
+      "$(json_escape "$lang")" \
+      "$(json_escape "$desc")"
+    tfirst=1
+    OLDIFS=$IFS
+    IFS=','
+    for tag in $tags; do
+      [ -z "$tag" ] && continue
+      if [ "$tfirst" = 1 ]; then
+        tfirst=0
+      else
+        printf ','
+      fi
+      printf '"%s"' "$(json_escape "$tag")"
+    done
+    IFS=$OLDIFS
+    printf ']}'
+  done
+  printf ']\n'
+}
+
+run_list() {
+  case "$format" in
+    text) emit_list_text ;;
+    json) emit_list_json ;;
+  esac
+}
+
+run_tree() {
+  [ -d "$extracted/$template" ] || die "Template '$template' not found at ${REPO}@${REF}"
+  printf '%s/\n' "$template"
+  ( cd "$extracted/$template" && find . -mindepth 1 -type f \
+      | sed -E 's|^\./|  |' \
+      | sort )
+  if [ -f "$extracted/$template/.compose.toml" ]; then
+    printf '\n'
+    printf 'Note: composite template — frontend/ is materialized from a sibling\n'
+    printf '      template at scaffold time (see .compose.toml). The tree above\n'
+    printf '      shows only the overlay diff, not the final scaffolded layout.\n'
+  fi
+}
+
+run_pick() {
+  [ -d "$extracted/$template" ] || die "Template '$template' not found at ${REPO}@${REF}"
+  if [ -f "$extracted/$template/.compose.toml" ]; then
+    die "--pick is not supported for composite templates ($template). Scaffold to a new directory instead."
+  fi
+
+  prefix="[DRY-RUN] "
+  [ -n "$apply" ] && prefix=""
+
+  src_root="$extracted/$template"
+
+  # Split pick on comma into a newline-separated list, then iterate. Using a
+  # while/read loop (instead of word-splitting the comma list) keeps paths with
+  # spaces working — though we expect none of our templates to ship such files.
+  # The inner loop emits only candidate file paths on stdout; not-found
+  # warnings go to stderr so they don't get re-processed by the outer loop.
+  printf '%s\n' "$pick" | tr ',' '\n' | while IFS= read -r path || [ -n "$path" ]; do
+    [ -z "$path" ] && continue
+    src="$src_root/$path"
+    if [ ! -e "$src" ]; then
+      warn "not found in template: $path"
+      continue
+    fi
+    if [ -d "$src" ]; then
+      find "$src" -type f
+    else
+      printf '%s\n' "$src"
+    fi
+  done | while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    rel="${f#$src_root/}"
+    target="$dest/$rel"
+    if [ -e "$target" ]; then
+      if [ -n "$overwrite" ]; then
+        action="overwrite"
+      else
+        action="skip"
+      fi
+    else
+      action="add"
+    fi
+    printf '%swould %s: %s\n' "$prefix" "$action" "$rel"
+    if [ -n "$apply" ] && [ "$action" != "skip" ]; then
+      mkdir -p "$(dirname "$target")"
+      cp "$f" "$target"
+    fi
+  done
+
+  if [ -z "$apply" ]; then
+    printf '\n'
+    printf 'Run with --apply to execute. Add --overwrite to replace existing files.\n'
+  fi
+}
+
+run_scaffold() {
+  if [ ! -d "$extracted/$template" ]; then
+    available=$(discover_templates | tr '\n' ' ')
+    die "Template '$template' not found at ${REPO}@${REF}. Available: $available"
+  fi
+
+  # Always invoke scaffold.sh. It rewrites template-name placeholders
+  # (Makefile / HTML / Go module path / package.json name etc.) so the
+  # resulting directory is a usable standalone project. Composite templates
+  # (those that ship a `.compose.toml`, e.g. go-react-spa) read sibling
+  # templates from $extracted during scaffolding, so the full tarball must
+  # remain available — do not pre-trim it down to $extracted/$template here.
+  info "Scaffolding $template -> $dest (name=$name${module:+ go-module-name=$module}${no_auth:+ no-auth})"
+  scaffold_args="template=$template dest=$dest name=$name"
+  [ -n "$module" ] && scaffold_args="$scaffold_args go-module-name=$module"
+  [ -n "$no_github_templates" ] && scaffold_args="$scaffold_args no-github-templates=1"
+  [ -n "$no_auth" ] && scaffold_args="$scaffold_args no-auth=1"
+  # shellcheck disable=SC2086
+  bash "$extracted/scripts/scaffold/scaffold.sh" $scaffold_args
+
+  info "Done: $dest"
+}
+
+case "$mode" in
+  list) run_list ;;
+  tree) run_tree ;;
+  pick) run_pick ;;
+  scaffold) run_scaffold ;;
+esac

--- a/scripts/scaffold/scaffold.sh
+++ b/scripts/scaffold/scaffold.sh
@@ -79,6 +79,11 @@ if [[ -f "$dest/.compose.toml" ]]; then
   compose_template "$dest" "$REPO_ROOT" "$name"
 fi
 
+# template.toml is metadata consumed by `download.sh --list` / `--tree`; the
+# scaffolded project does not need it. Composite templates may also drag in
+# the base template's template.toml under frontend/ — drop that too.
+rm -f "$dest/template.toml" "$dest/frontend/template.toml"
+
 # --- shared-react-ui merge (runs after compose_template so composed sub-trees
 #     can also opt-in via their own .shared-ui.toml). ---
 if [[ -f "$dest/.shared-ui.toml" ]]; then


### PR DESCRIPTION
## 概要

`download.sh` に `--list` / `--tree` / `--pick` の3モードを追加し、既存プロジェクトに boilerplate の特定ファイルだけを後から取り込めるようにする。scaffold モード（既存挙動）は変更なし。あわせて `--list` / `--tree` のデータソースとして各テンプレ直下に `template.toml` を追加。

## 関連 Issue

Closes: #203

## Affects

なし

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

ローカル tarball を作って `MY_BOILERPLATE_TARBALL_URL` 経由でテストできる:

```bash
# branch の中身を tarball 化
testdir=$(mktemp -d)
mkdir -p "$testdir/work"
cp -a . "$testdir/work/my-boilerplate-test"
rm -rf "$testdir/work/my-boilerplate-test/.git"
( cd "$testdir/work" && tar -czf "$testdir/repo.tar.gz" my-boilerplate-test )

# --list (text)
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh --list

# --list (json) — AI 向け
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh --list --format=json | python3 -m json.tool

# --tree
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-cli --tree
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa --tree   # composite 注記が末尾に出る

# --pick dry-run
mkdir -p "$testdir/existing"; echo readme > "$testdir/existing/README.md"
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-cli "$testdir/existing" \
  --pick=Makefile,.golangci.yml,internal/greet/

# --pick apply
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-cli "$testdir/existing" \
  --pick=Makefile,.golangci.yml,internal/greet/ --apply

# composite テンプレで --pick はエラー
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/existing" --pick=Makefile
# → [ERROR] --pick is not supported for composite templates ...

# 既存 scaffold モードの回帰
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-cli "$testdir/new-project"
find "$testdir/new-project" -name 'template.toml'  # 空（scaffold 後は削除される）
```

### 動作確認シナリオ

- [x] `--list` text モードで14テンプレが3列整形表示される
- [x] `--list --format=json` で 14要素の JSON 配列が出力され `python -m json.tool` でパースできる
- [x] `--tree go-cli` がファイル列を flat sorted で表示する
- [x] `--tree go-react-spa` の末尾に composite 注記が出る
- [x] `--pick` dry-run が `[DRY-RUN] would add/overwrite/skip` を表示し、ファイルは変更されない
- [x] `--apply` で実コピー、`--overwrite` で既存ファイル置換、無指定は skip
- [x] composite テンプレへの `--pick` はエラーで弾かれる
- [x] 存在しないパスを `--pick` に渡すと `[WARN] not found in template:` が stderr に出る
- [x] scaffold モードの go-cli / go-react-spa が従来通り動作し、scaffold 結果から `template.toml` が削除されている

## テスト

- [ ] `make ci` PASS
- [x] 新規/変更コードに対するユニットテストを追加した — ローカル動作確認スクリプトで上記シナリオを全網羅

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（本 PR で issue #203 を close）
- [x] README の更新が必要なら反映した — `download.sh` ヘッダの Usage / Examples ブロックを刷新
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点

- **メタデータの単一情報源**: 各テンプレ直下 `template.toml` を「テンプレが何者か」を語る単一情報源にした。集中管理（`templates.toml`）にすると新テンプレ追加時に drift する。`--list` は `find -name template.toml` で動的に集めるので、テンプレ追加時の追加コストは「`template.toml` を1つ置くだけ」。
- **composite テンプレの `--pick` 非対応**: `go-react-spa` のような composite は `frontend.overlay/` だけが overlay として存在し、base `react-spa/` 無しでは意味を成さない。中途半端にコピーするより明示エラーで弾く方が安全。compose 後の materialized tree から pick したいという要望が出てきたら別途検討。
- **scaffold 後 `template.toml` 削除**: scaffold 結果はエンドユーザー成果物なので、`--list` 用メタデータは不要。composite テンプレ向けに `frontend/template.toml` も同時に消すフォローアップ込み。
- **テスト容易性**: `MY_BOILERPLATE_TARBALL_URL` 環境変数で tarball URL 上書きを可能にした。CI で「ブランチ自身」を tarball 化して `--list` / `--pick` を検証する scaffold-verify ワークフローを追加するフォローアップ余地あり（本 PR スコープ外）。
- **`go.mod` / `package.json` の `--pick`**: 現状は placeholder 置換が走らないので、これらは `--pick` 対象に含めない運用。要望が出てきたら `--pick --apply --name=NAME` で scaffold.sh 相当の置換を走らせる拡張を検討。
