### PR TITLE
feat(download.sh): composite テンプレで非 frontend パスの --pick を許容する

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -58,10 +58,10 @@
 #   --overwrite             When --apply is set, replace existing files at the
 #                           destination. Without --overwrite the default is to
 #                           skip existing files.
-#   Note: --pick is not supported for composite templates (those with a
-#         .compose.toml). The overlay-only file layout is meaningful only after
-#         compose, so copying overlay files into an existing project would do
-#         the wrong thing.
+#   Composite templates (those with a .compose.toml) are supported, but
+#   `frontend/`, `frontend.overlay/`, and `.compose.toml` itself are skipped
+#   with a [WARN]: those entries only make sense after scaffold-time compose
+#   and copying them into an existing project would do the wrong thing.
 #
 # Go templates (scaffold mode): the `module` line in go.mod is auto-set to
 # basename(<dest>), producing a local-only module suitable for prototyping. If
@@ -371,9 +371,9 @@ run_tree() {
 
 run_pick() {
   [ -d "$extracted/$template" ] || die "Template '$template' not found at ${REPO}@${REF}"
-  if [ -f "$extracted/$template/.compose.toml" ]; then
-    die "--pick is not supported for composite templates ($template). Scaffold to a new directory instead."
-  fi
+
+  is_composite=""
+  [ -f "$extracted/$template/.compose.toml" ] && is_composite="1"
 
   prefix="[DRY-RUN] "
   [ -n "$apply" ] && prefix=""
@@ -385,8 +385,21 @@ run_pick() {
   # spaces working — though we expect none of our templates to ship such files.
   # The inner loop emits only candidate file paths on stdout; not-found
   # warnings go to stderr so they don't get re-processed by the outer loop.
+  #
+  # For composite templates, frontend/ and frontend.overlay/ only make sense
+  # after scaffold-time compose, and .compose.toml itself is a scaffold-only
+  # manifest. Skip those three with a [WARN] so callers see why their path was
+  # dropped instead of getting a silent partial result.
   printf '%s\n' "$pick" | tr ',' '\n' | while IFS= read -r path || [ -n "$path" ]; do
     [ -z "$path" ] && continue
+    if [ -n "$is_composite" ]; then
+      case "$path" in
+        frontend | frontend/* | frontend.overlay | frontend.overlay/* | .compose.toml)
+          warn "skip overlay path: $path (composite template '$template' — only meaningful after scaffold-time compose)"
+          continue
+          ;;
+      esac
+    fi
     src="$src_root/$path"
     if [ ! -e "$src" ]; then
       warn "not found in template: $path"


### PR DESCRIPTION
## 概要

PR #220 で導入した `--pick` は composite テンプレ（`.compose.toml` を持つもの、現状は `go-react-spa` のみ）を一律エラーで弾いていた。しかし Go 側ファイル（`cmd/`, `internal/` 等）はテンプレ直下に直接存在し overlay ではない（base 依存なし）ため、symphony#6 のような「既存 cobra CLI に `internal/web` 相当だけ追加」ユースケースを救えなかった。

composite 一律 die を外し、`frontend/` / `frontend.overlay/` / `.compose.toml` だけを `[WARN] skip overlay path:` で除外する形に変更した。

## 関連 Issue

Refs: #219
Closes: #221

## Affects

なし

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

PR #220 と同じパターンでローカル tarball を経由して確認:

```bash
# branch の中身を tarball 化
testdir=$(mktemp -d)
mkdir -p "$testdir/work"
cp -a . "$testdir/work/my-boilerplate-test"
rm -rf "$testdir/work/my-boilerplate-test/.git"
( cd "$testdir/work" && tar -czf "$testdir/repo.tar.gz" my-boilerplate-test )

# 1) composite go-react-spa --pick 非 frontend (dry-run)
mkdir -p "$testdir/existing-composite"; echo readme > "$testdir/existing-composite/README.md"
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/existing-composite" \
  --pick=cmd/server/main.go,internal/handler/
# → would add: cmd/server/main.go / internal/handler/{handler,user,handler_test}.go

# 2) --apply で実コピー
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/existing-composite" \
  --pick=cmd/server/main.go,internal/handler/ --apply

# 3) frontend/ 含むパスは WARN + skip
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/existing-composite" \
  --pick=frontend/vite.config.ts,cmd/server/main.go
# → [WARN] skip overlay path: frontend/vite.config.ts
#   [DRY-RUN] would add: cmd/server/main.go

# 4) frontend.overlay/ と .compose.toml と裸の frontend / frontend.overlay も WARN + skip
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/existing-composite" \
  --pick=frontend.overlay/vite.config.ts,.compose.toml,frontend,frontend.overlay

# 5) 非 composite (go-cli) 回帰確認: PR #220 と同一動作
mkdir -p "$testdir/existing-gocli"; echo readme > "$testdir/existing-gocli/README.md"
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-cli "$testdir/existing-gocli" \
  --pick=Makefile,.golangci.yml,internal/greet/ --apply

# 6) scaffold モード回帰: composite scaffold で frontend/ が compose されること
MY_BOILERPLATE_TARBALL_URL="file://$testdir/repo.tar.gz" \
  sh scripts/download.sh go-react-spa "$testdir/new-grs-project"
```

### 動作確認シナリオ

- [x] composite テンプレで `cmd/server/main.go,internal/handler/` の dry-run / `--apply` が動作する
- [x] composite テンプレで `frontend/`, `frontend.overlay/`, `.compose.toml` を含む `--pick` が `[WARN] skip overlay path:` で除外され、それ以外のパスは正しく pick される
- [x] 非 composite (`go-cli`) の `--pick` は PR #220 と完全に同一動作（回帰なし）
- [x] scaffold モードは挙動不変 (`go-react-spa` 新規 scaffold で `frontend/` が compose される)

## テスト

- [ ] `make ci` PASS
- [x] 新規/変更コードに対するユニットテストを追加した（既存 scaffold-verify CI で回帰検知。`--pick` の追加検証はローカル動作確認手順でカバー）

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（親 #219 には `Refs:`、sub-issue #221 には `Closes:`）
- [x] README の更新が必要なら反映した（download.sh のヘッダコメント内ドキュメントを更新済み、README からの直接参照なし）
- [x] 機密情報（API キー等）を含まない
