### PR TITLE
refactor(go-react-spa): server lifecycle を internal/server.Run(ctx) に分離

### DIFF
--- a/go-react-spa/README.md
+++ b/go-react-spa/README.md
@@ -28,8 +28,9 @@ its Makefile.
 ```
 go-react-spa/
 ├── .compose.toml         # composite manifest (base + overlay)
-├── cmd/server/main.go    # binary entrypoint
+├── cmd/server/main.go    # binary entrypoint (signal wiring + server.Run)
 ├── internal/
+│   ├── server/           # Run(ctx) error — config + DB + HTTP lifecycle
 │   ├── handler/          # HTTP + JSON API
 │   └── static/
 │       ├── static.go         # FileSystem interface
@@ -158,6 +159,47 @@ If the project will be published, after scaffolding run:
 ```bash
 go mod edit -module github.com/<user>/<repo>
 ```
+
+## cobra subcommand への組み込み
+
+Server lifecycle は `internal/server` パッケージの `Run(ctx context.Context) error`
+に切り出されている。`cmd/server/main.go` は `signal.NotifyContext` でシグナルを
+受ける薄ラッパで、本体は `server.Run()` 一行。
+
+既存の cobra CLI に「サーバ起動」サブコマンドとして組み込む場合、`Run()` を
+import してそのまま `RunE` に渡せる:
+
+```go
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	// このテンプレートを scaffold した module path に合わせて差し替え:
+	"<your-module>/internal/server"
+)
+
+func newServeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Start the API server (graceful shutdown on SIGINT/SIGTERM)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// cobra が `cmd.SetContext(signal.NotifyContext(...))` で
+			// シグナル付き ctx を流していれば、ここで再度 signal.Notify は不要。
+			return server.Run(cmd.Context())
+		},
+	}
+}
+```
+
+`Run()` は内部で `envconfig` から `PORT` / `DATABASE_DSN` / `SHUTDOWN_TIMEOUT`
+等を読み込み、`ctx` が cancel されたら `SHUTDOWN_TIMEOUT` 内で graceful
+shutdown して `nil` を返す。サーバ起動が失敗した場合は wrapped error を返すので、
+cobra 側の `SilenceErrors` / `SilenceUsage` と組み合わせて適切に表示できる。
+
+`scripts/download.sh go-react-spa <existing-cobra-repo> --pick=internal/server/,internal/handler/,internal/service/,internal/repository/,internal/model/,internal/static/`
+で必要な内部パッケージだけ既存リポジトリへ取り込んで使うパターンも想定している
+（pick 後に import path を自分の module 名に rewrite する手間は別途必要）。
 
 ## Removing authentication
 

--- a/go-react-spa/cmd/server/main.go
+++ b/go-react-spa/cmd/server/main.go
@@ -2,107 +2,20 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/glebarez/sqlite"
-	"github.com/lmittmann/tint"
-	"github.com/sethvargo/go-envconfig"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
-
-	"go-react-spa/internal/handler"
-	"go-react-spa/internal/model"
-	"go-react-spa/internal/repository"
-	"go-react-spa/internal/service"
-	"go-react-spa/internal/static"
+	"go-react-spa/internal/server"
 )
 
-type Config struct {
-	Port            string        `env:"PORT,default=8080"`
-	DatabaseDSN     string        `env:"DATABASE_DSN,default=app.db"`
-	JWTSecret       string        `env:"JWT_SECRET,default=change-me-in-production"`
-	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT,default=10s"`
-	JWTTTL          time.Duration `env:"JWT_TTL,default=24h"`
-}
-
 func main() {
-	var logLevel slog.LevelVar
-	if l := os.Getenv("LOG_LEVEL"); l != "" {
-		_ = logLevel.UnmarshalText([]byte(l))
-	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	var logHandler slog.Handler
-	if os.Getenv("APP_ENV") == "production" {
-		logHandler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
-	} else {
-		logHandler = tint.NewHandler(os.Stderr, &tint.Options{
-			Level:      &logLevel,
-			TimeFormat: time.Kitchen,
-		})
-	}
-	slog.SetDefault(slog.New(logHandler))
-
-	var cfg Config
-	if err := envconfig.Process(context.Background(), &cfg); err != nil {
-		slog.Error("failed to load config", "error", err)
+	if err := server.Run(ctx); err != nil {
+		slog.Error("server error", "error", err)
 		os.Exit(1)
 	}
-
-	db, err := gorm.Open(sqlite.Open(cfg.DatabaseDSN), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	if err != nil {
-		slog.Error("failed to connect to database", "error", err)
-		os.Exit(1)
-	}
-	if err := db.AutoMigrate(&model.User{}); err != nil {
-		slog.Error("failed to migrate database", "error", err)
-		os.Exit(1)
-	}
-
-	if os.Getenv("APP_ENV") == "production" {
-		gin.SetMode(gin.ReleaseMode)
-	}
-
-	repo := repository.NewUserRepository(db)
-	svc := service.NewUserService(repo)
-	h := handler.NewHandler(svc)
-
-	srv := &http.Server{
-		Addr:         ":" + cfg.Port,
-		Handler:      h.Routes(static.Handler()),
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  60 * time.Second,
-	}
-
-	go func() {
-		slog.Info("starting server", "port", cfg.Port)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
-		}
-	}()
-
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
-
-	slog.Info("shutting down server")
-	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
-	defer cancel()
-
-	if err := srv.Shutdown(ctx); err != nil {
-		slog.Error("server shutdown error", "error", err)
-		os.Exit(1)
-	}
-
-	slog.Info("server stopped")
 }

--- a/go-react-spa/internal/server/server.go
+++ b/go-react-spa/internal/server/server.go
@@ -1,0 +1,130 @@
+// Package server boots the API server.
+//
+// Run() is split out of cmd/server/main.go so the same lifecycle can be
+// reused from a cobra subcommand: main() handles signal wiring, while Run()
+// owns config loading, DB setup, HTTP listener, and graceful shutdown.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/lmittmann/tint"
+	"github.com/sethvargo/go-envconfig"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"go-react-spa/internal/handler"
+	"go-react-spa/internal/model"
+	"go-react-spa/internal/repository"
+	"go-react-spa/internal/service"
+	"go-react-spa/internal/static"
+)
+
+type Config struct {
+	Port            string        `env:"PORT,default=8080"`
+	DatabaseDSN     string        `env:"DATABASE_DSN,default=app.db"`
+	JWTSecret       string        `env:"JWT_SECRET,default=change-me-in-production"`
+	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT,default=10s"`
+	JWTTTL          time.Duration `env:"JWT_TTL,default=24h"`
+}
+
+// Run boots the API server and blocks until ctx is canceled (graceful
+// shutdown, returns nil) or the underlying http.Server returns a fatal
+// error (returns that error).
+//
+// Resource ownership — logger / DB / HTTP server — is intentionally kept
+// inside Run() so cobra integrations don't have to thread anything in:
+//
+//	RunE: func(cmd *cobra.Command, _ []string) error {
+//	    return server.Run(cmd.Context())
+//	}
+func Run(ctx context.Context) error {
+	setupLogger()
+
+	var cfg Config
+	if err := envconfig.Process(ctx, &cfg); err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	db, err := gorm.Open(sqlite.Open(cfg.DatabaseDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return fmt.Errorf("connect database: %w", err)
+	}
+	if err := db.AutoMigrate(&model.User{}); err != nil {
+		return fmt.Errorf("migrate database: %w", err)
+	}
+
+	if os.Getenv("APP_ENV") == "production" {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
+	repo := repository.NewUserRepository(db)
+	svc := service.NewUserService(repo)
+	h := handler.NewHandler(svc)
+
+	srv := &http.Server{
+		Addr:         ":" + cfg.Port,
+		Handler:      h.Routes(static.Handler()),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// The server runs in a goroutine; its terminal state — either a real
+	// error or http.ErrServerClosed after Shutdown — is funneled back
+	// through errCh so the select below is the single decision point.
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("starting server", "port", cfg.Port)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		slog.Info("shutting down server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("server shutdown: %w", err)
+		}
+		// Drain the goroutine so the test (and any caller) can rely on
+		// Run() not leaving a server-side goroutine alive after return.
+		<-errCh
+		slog.Info("server stopped")
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+func setupLogger() {
+	var logLevel slog.LevelVar
+	if l := os.Getenv("LOG_LEVEL"); l != "" {
+		_ = logLevel.UnmarshalText([]byte(l))
+	}
+
+	var logHandler slog.Handler
+	if os.Getenv("APP_ENV") == "production" {
+		logHandler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: &logLevel})
+	} else {
+		logHandler = tint.NewHandler(os.Stderr, &tint.Options{
+			Level:      &logLevel,
+			TimeFormat: time.Kitchen,
+		})
+	}
+	slog.SetDefault(slog.New(logHandler))
+}

--- a/go-react-spa/internal/server/server_test.go
+++ b/go-react-spa/internal/server/server_test.go
@@ -1,0 +1,43 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go-react-spa/internal/server"
+)
+
+// TestRun_ShutsDownOnCtxCancel exercises the contract that Run(ctx) returns
+// nil after ctx is canceled and the HTTP server has drained.
+//
+// PORT=0 lets the kernel pick an unused port so parallel test runs and busy
+// CI hosts don't fight over :8080. DATABASE_DSN=:memory: avoids leaving an
+// app.db file in the working directory.
+func TestRun_ShutsDownOnCtxCancel(t *testing.T) {
+	t.Setenv("PORT", "0")
+	t.Setenv("DATABASE_DSN", ":memory:")
+	t.Setenv("SHUTDOWN_TIMEOUT", "2s")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Run(ctx)
+	}()
+
+	// Give the listener a moment to come up before signaling shutdown.
+	// Without this, Shutdown() can race with ListenAndServe()'s setup.
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run() returned error after ctx cancel: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return within 5s after ctx cancel")
+	}
+}


### PR DESCRIPTION
## 概要

`go-react-spa/cmd/server/main.go` に直書きだった logger / Config / DB / HTTP server + graceful shutdown を `internal/server.Run(ctx context.Context) error` に切り出す。`main()` は `signal.NotifyContext` でシグナル付き ctx を作り `server.Run()` を呼ぶだけの薄ラッパに。

既存 cobra CLI に「サーバ起動」サブコマンドとして組み込む場合、

```go
RunE: func(cmd *cobra.Command, _ []string) error {
    return server.Run(cmd.Context())
}
```

の 1 行で済むようになる（symphony#6 想定）。scaffold 経路 (`./bin/server`) の挙動は現行同一。

## 関連 Issue

Refs: #219
Closes: #222

## Affects

なし

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 設計判断

[#222 のコメント](https://github.com/rengotaku/my-boilerplate/issues/222#issuecomment-4437050419) で挙げた懸念に対する確定方針:

1. **配置 (Concern 1)**: `Run()` は `internal/server/server.go` に置く（案 b）。同一 module 内 cobra からのみ import 可能。公開 API 化はまだコミットせず、`--pick` 経路（PR #223）と組み合わせて利用者の repo に取り込んでもらうワークフローを前提にする
2. **テストの port/db 衝突 (Concern 2)**: `t.Setenv("PORT","0")` + `DATABASE_DSN=":memory:"` + `SHUTDOWN_TIMEOUT=2s` で env override する形をテストファイル先頭のコメントに明記
3. **goroutine error 伝播 (Concern 3)**: buffered channel + `select` で実装。`errgroup` 依存は追加しない。`os.Exit(1)` を Run() 内から呼ぶ経路は撤廃し、cobra ユーザが自分のエラー処理を貫通させられるようにした
4. **noauth scaffold (Concern 4)**: `scripts/scaffold/lib/noauth.sh` は frontend のみ書き換えるため `internal/server` には触れない。実際に scaffold して `go test ./...` が PASS することを確認済み

## 動作確認手順（ローカル起動）

```bash
cd go-react-spa

# 1) Run() の単体テスト（PORT=0 / DATABASE_DSN=:memory: で衝突回避）
go test ./internal/server/ -v -count=1

# 2) 全テスト回帰確認
go test ./... -count=1

# 3) 実バイナリで SIGTERM → graceful shutdown
mkdir -p bin
go build -tags dev -o bin/server ./cmd/server
PORT=18723 DATABASE_DSN=":memory:" SHUTDOWN_TIMEOUT=3s ./bin/server &
PID=$!
sleep 1
kill -TERM $PID
wait $PID
# → exit 0、"shutting down server" → "server stopped" がログに出る

# 4) noauth scaffold で Run() 構造が維持され、テストも PASS する
testdir=$(mktemp -d)
bash scripts/scaffold/scaffold.sh \
  template=go-react-spa-noauth \
  dest="$testdir/noauth-app" \
  name=noauth-app go-module-name=noauth-app
cd "$testdir/noauth-app"
go test ./... -count=1   # 全 PASS
ls internal/server/      # server.go + server_test.go が存在
```

### 動作確認シナリオ

- [x] `internal/server/server_test.go::TestRun_ShutsDownOnCtxCancel` が `cancel()` 後 `Run()` が `nil` を返すことを検証して PASS
- [x] `go test ./...` 全 PASS（handler / middleware / model / repository / server / service / static）
- [x] 実バイナリ起動 → SIGTERM → 「shutting down server」「server stopped」ログ → exit 0
- [x] `go-react-spa-noauth` scaffold 後も `internal/server/` 構造が維持され、scaffolded 側で `go test ./...` 全 PASS
- [x] `golangci-lint run ./...` 0 issues

## テスト

- [ ] `make ci` PASS
- [x] 新規/変更コードに対するユニットテストを追加した（`internal/server/server_test.go`）

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（親 #219 には `Refs:`、sub-issue #222 には `Closes:`）
- [x] README の更新が必要なら反映した（「## cobra subcommand への組み込み」セクション + project structure の `internal/server/` 追記）
- [x] 機密情報（API キー等）を含まない
