### PR TITLE
fix(scaffold): scaffolded project が箱から出してそのまま動くように 3 件修正 (#227)

### DIFF
--- a/scripts/scaffold/lib/ci.sh
+++ b/scripts/scaffold/lib/ci.sh
@@ -133,6 +133,7 @@ transform_workflow() {
   BEGIN {
     in_paths = 0
     in_defaults = 0
+    in_compose_step = 0
   }
 
   # Replace workflow name
@@ -174,17 +175,40 @@ transform_workflow() {
     next
   }
 
-  # Strip template prefix from cache-dependency-path
-  /cache-dependency-path:/ {
+  # Strip template prefix from go-version-file
+  /go-version-file:/ {
     gsub(template "/", "")
     print
     next
   }
 
-  # Strip template prefix from node-version-file / python-version-file
+  # Strip template prefix from cache-dependency-path; also remap
+  # react-spa/ -> frontend/ for the go-react-spa composite template
+  /cache-dependency-path:/ {
+    gsub(template "/", "")
+    gsub("react-spa/", "frontend/")
+    print
+    next
+  }
+
+  # Strip template prefix from node-version-file / python-version-file; also
+  # remap react-spa/ -> frontend/ for the go-react-spa composite template
   /node-version-file:/ || /python-version-file:/ {
     gsub(template "/", "")
+    gsub("react-spa/", "frontend/")
     print
+    next
+  }
+
+  # Skip the "Compose frontend" step (pre-composed during scaffold; make compose is a no-op)
+  /^      - name: Compose frontend/ {
+    in_compose_step = 1
+    next
+  }
+  in_compose_step && /^      - / {
+    in_compose_step = 0
+  }
+  in_compose_step {
     next
   }
 

--- a/scripts/scaffold/lib/common.sh
+++ b/scripts/scaffold/lib/common.sh
@@ -174,7 +174,7 @@ resolve_node_version_files() {
       info "[node-version] $(basename "$f"): $ver -> $resolved"
       printf '%s\n' "$resolved" > "$f"
     else
-      warn "[node-version] cannot resolve Node.js $ver to a full version in $(basename "$f"); leaving as-is"
+      die "[node-version] cannot resolve Node.js $ver to a full version in $(basename "$f"). Install nodenv or activate Node.js ${ver}.x and re-run scaffold."
     fi
   done
 }

--- a/scripts/scaffold/lib/compose.sh
+++ b/scripts/scaffold/lib/compose.sh
@@ -118,6 +118,29 @@ compose_template() {
   rm -f "$manifest"
   rm -rf "$overlay_src"
 
+  # Replace the monorepo-specific "frontend/ is composed at build time" gitignore
+  # block with artifact-only entries so the scaffolded project tracks its own
+  # frontend/ source tree normally.
+  if [[ -f "$dest/.gitignore" ]]; then
+    local tmp
+    tmp="$(mktemp)"
+    awk '
+      /^# `frontend\/` is composed at build time/ { skip = 1; next }
+      skip && /^frontend\/$/ {
+        skip = 0
+        print "# Frontend build artifacts"
+        print "frontend/node_modules/"
+        print "frontend/dist/"
+        print "frontend/coverage/"
+        next
+      }
+      skip { next }
+      { print }
+    ' "$dest/.gitignore" > "$tmp"
+    mv "$tmp" "$dest/.gitignore"
+    info "[compose] .gitignore: replaced monorepo frontend/ block with artifact entries"
+  fi
+
   if [[ -f "$dest/Makefile" ]]; then
     strip_compose_makefile "$dest/Makefile"
   fi


### PR DESCRIPTION
## 概要

`go-react-spa` / `go-react-spa-noauth` を `scripts/scaffold/scaffold.sh` でスキャフォールドした後、boilerplate モノレポ前提が leak していて scaffolded project がそのまま動かない 3 点を scaffold 時に吸収するよう修正した（#227）。

## 関連 Issue

Closes: #227

## Affects

なし

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

```bash
# 1. scaffold（Node.js 22 が active な状態で実行）
rm -rf /tmp/test-go-react-spa
bash scripts/scaffold/scaffold.sh \
  template=go-react-spa \
  dest=/tmp/test-go-react-spa \
  name=test-go-react-spa \
  go-module-name=github.com/test/test-go-react-spa

# 2. 修正点を目視確認
grep -E 'go-version-file|node-version-file|cache-dependency-path|compose' \
  /tmp/test-go-react-spa/.github/workflows/ci.yml
cat /tmp/test-go-react-spa/.gitignore
cat /tmp/test-go-react-spa/frontend/.node-version
cat /tmp/test-go-react-spa/frontend/.nvmrc

# 3. ビルド & 起動
cd /tmp/test-go-react-spa
make install
make build
PORT=18091 ./bin/server &
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/             # 200
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/api/v1/users # 200
curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:18091/users        # 200
```

### 動作確認シナリオ

- [x] `go-react-spa` を scaffold → `.github/workflows/ci.yml` に `go-react-spa/go.mod` / `react-spa/.node-version` / `react-spa/package-lock.json` / `make compose` が残らず、`go.mod` / `frontend/.node-version` / `frontend/package-lock.json` に書き換わる
- [x] `go-react-spa-noauth` を scaffold → 同上が成立し、auth 削除と両立する
- [x] scaffolded project の `.gitignore` に bare `frontend/` 行が無く、`frontend/node_modules/` / `frontend/dist/` / `frontend/coverage/` の 3 行が入る
- [x] scaffolded project の `frontend/.node-version` と `frontend/.nvmrc` がフルセマー（例 `22.21.1`）になる
- [x] Node.js 22 系を解決できない環境で scaffold すると ERROR で停止する（無言で `22` を残さない）
- [x] `make install && make build` 完走、`./bin/server` で SPA index / API / SPA fallback が 200 を返す
- [x] 非 composite テンプレ（`go-rest-api`、`react-spa` 単体）にも回帰がない

## テスト

- [x] `make ci` PASS（scaffold スクリプト関連の変更のみ、Go/JS テストへの影響なし）
- [x] 新規/変更コードに対するユニットテストを追加した
  - `scaffold-verify-go-react-spa.yml` / `scaffold-verify-go-react-spa-noauth.yml` に 3 修正点それぞれの assertion ステップを追加

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（親 issue には `Refs:`、sub-issue には `Closes:`）
- [x] README の更新が必要なら反映した（変更不要）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点

### 3 修正点の内訳（commit `1574bac`）

| 修正対象 | Before | After |
|---|---|---|
| `ci.yml`: `go-version-file` | `go-react-spa/go.mod` | `go.mod` |
| `ci.yml`: `node-version-file` | `react-spa/.node-version` | `frontend/.node-version` |
| `ci.yml`: `cache-dependency-path` (Node) | `react-spa/package-lock.json` | `frontend/package-lock.json` |
| `ci.yml`: `Compose frontend` step | `make compose` を実行（既に no-op） | step ごと削除 |
| `.gitignore`: composite ブロック | `frontend/`（ソースも除外） | `frontend/node_modules/` / `dist/` / `coverage/` |
| `.node-version` / `.nvmrc` 解決失敗時 | `[WARN] leaving as-is`（無言で `22` 残置） | `die` で scaffold 停止 |

### Node バージョン解決を A→C 多段ではなく B（die）にした理由

issue 提案では `nodejs.org` 越し → 同梱マップ → die の多段フォールバックも候補だったが、本 PR では既存の解決源（nodenv install --list / 現在 active な node）で解決できない場合に **die にする** 最小修正に留めた。

- 既存の挙動: `WARN` を出して `22` を残し、`make install` で `nodenv: version '22' is not installed` で詰まる（issue 報告の挙動）
- 本 PR の挙動: `die` で scaffold を停止し、ユーザーに `nodenv` セットアップか Node.js 22.x の active 化を要求する
- 観測した範囲では `setup-node@v6`（CI）と `mise/nodenv`（手元）のどちらかは既に整っているケースが多く、ネットワーク越し解決まで踏み込む費用対効果が薄いため

将来 nodejs.org 越しに解決する経路を追加したくなったら、`resolve_node_version_files` の最後（`die` 直前）に挟む形で増設できる。

### 修正対象テンプレ

`make compose` step と composite `.gitignore` ブロックは `.compose.toml` を持つ `go-react-spa` ファミリーにしか出現しないので、それ以外のテンプレ（`go-rest-api`、`react-spa` 単体、`python-*` 等）には影響しない。Node バージョン解決の格上げ（`warn` → `die`）は全 React 系テンプレに効く。

### scaffold-verify への assertion 追加（commit `8bdc2b5`）

`scripts/scaffold/lib/` の変更が PR で押せたので、回帰検知用の assertion を `scaffold-verify-go-react-spa{,-noauth}.yml` に追加した（"Verify CI workflow paths are rewritten" / "Verify .gitignore excludes only frontend build artifacts" / "Verify .node-version and .nvmrc have full semver"）。
