### PR TITLE
fix(go-react-admin): Tailwind v4 が compose 済み admin/ui のクラスを生成するよう @source 指定

### DIFF
--- a/go-react-admin/frontend/src/index.css
+++ b/go-react-admin/frontend/src/index.css
@@ -1,6 +1,16 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/*
+ * src/components/ui and src/components/admin are composed from shared-react-ui
+ * and kept out of VCS in the monorepo (see .gitignore). Tailwind v4's automatic
+ * source detection skips .gitignored paths, which would drop every utility used
+ * only by those components. Register them explicitly so their classes are always
+ * generated. (Harmless once scaffolded — the files are tracked there.)
+ */
+@source "./components/ui";
+@source "./components/admin";
+
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
## 概要

`go-react-admin` の管理画面で **admin/ui コンポーネントが未スタイル**（DataTable・StatusBadge・Pagination・charts 等が素の見た目）になっていた不具合を修正する。

## 関連 Issue

Refs: #246

## 原因

- `frontend/src/components/{ui,admin}` は `shared-react-ui` から compose する成果物で、monorepo では `.gitignore`（managed block）でディレクトリごと無視している。
- **Tailwind v4 の `@tailwindcss/vite` 自動ソース検出は `.gitignore` 配下をスキャンしない**ため、これらのコンポーネント専用 utility class が一切生成されず、当該コンポーネントだけ未スタイルになっていた（Layout 等 非 gitignore のクラスは生成されていた）。

## 修正

`frontend/src/index.css` に明示スキャン指定を追加:
```css
@source "./components/ui";
@source "./components/admin";
```
scaffold 後は managed block が外れて追跡対象になるため、この指定は無害でそのまま機能する。

## 変更タイプ

- [x] fix: バグ修正

## 動作確認

- `npm run build` の CSS 出力が **14KB → 22.7KB** に増加
- `bg-amber-100` / `bg-red-100` / `bg-indigo-50` 等 admin クラスの生成を確認
- StatusBadge の全 tone class（green/amber/red/blue/indigo/slate 系）が CSS に含まれることを確認
- embed バイナリ再ビルド → `:8084` で配信される CSS に admin スタイルが含まれることを確認

## テスト

- [x] `npm run build` PASS / 既存 vitest・lint は不変（CSS のみの変更）

## チェックリスト

- [x] `Refs:` 使用（親 issue は close しない）
- [x] 機密情報を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足

- 同種の構成（gitignore された compose 済み `src/components/ui`）の `react-spa` 系にも同じ潜在不具合がある可能性があるが、本 PR の対象外。別途確認する価値あり。