### PR TITLE
feat(go-react-admin): 設定を env/toml に二層化し toml を Config 画面から編集＋再起動で反映

### DIFF
--- a/go-react-admin/.gitignore
+++ b/go-react-admin/.gitignore
@@ -3,3 +3,6 @@ tmp/
 coverage.out
 *.db
 data/
+# Runtime config written by the admin console (editable worker_interval /
+# shutdown_timeout). Regenerated with defaults on first boot.
+config.toml

--- a/go-react-admin/Makefile
+++ b/go-react-admin/Makefile
@@ -11,6 +11,10 @@ COVERAGE_FILE := coverage.out
 PORT ?= 8084
 FRONTEND_PORT ?= 5175
 FRONTEND_DIR := frontend
+# Go source roots only. Listing them explicitly keeps `go test ./...` from
+# walking into frontend/node_modules, where vendored packages (e.g. flatted's
+# golang sample) would otherwise show up as 0%-covered and skew coverage.
+GO_PKGS := ./cmd/... ./internal/...
 
 # shared-react-ui: composed in-place from the sibling repo dir during local dev.
 # Outside the monorepo (after scaffold) the source dir is absent and the
@@ -99,7 +103,7 @@ format-check: compose-ui
 
 ## test: Run Go tests
 test:
-	go test ./...
+	go test $(GO_PKGS)
 
 ## test-frontend: Run frontend tests
 test-frontend: compose-ui
@@ -107,7 +111,7 @@ test-frontend: compose-ui
 
 ## test-cov: Run Go tests with coverage
 test-cov:
-	go test -coverprofile=$(COVERAGE_FILE) ./...
+	go test -coverprofile=$(COVERAGE_FILE) $(GO_PKGS)
 	go tool cover -func=$(COVERAGE_FILE) | tail -1
 
 ## test-watch: Run frontend tests in watch mode

--- a/go-react-admin/README.md
+++ b/go-react-admin/README.md
@@ -80,7 +80,9 @@ go-react-admin/
 | GET    | /api/runs                     | run 一覧（`job_id` / ページング クエリ対応） |
 | GET    | /api/runs/:id                 | run 詳細（phases / metrics / ログ含む）      |
 | GET    | /api/metrics/aggregate        | メトリクスの集計（ダッシュボード用）         |
-| GET    | /api/config                   | 実行中の設定（secrets を含まない）           |
+| GET    | /api/config                   | 設定一覧（env=読み取り専用 / toml=編集可 を判別）|
+| PUT    | /api/config                   | toml 設定の更新（再起動で反映。env は不可）  |
+| POST   | /api/restart                  | worker+web の再起動（toml 値を再読込）        |
 | GET    | /{anything-else}              | SPA fallback（埋め込み dist/、クライアント側ルーティング用） |
 
 ### shared-react-ui の admin compose
@@ -147,13 +149,33 @@ make clean           # bin/ / coverage.out / *.db / data/ / node_modules / dist/
 
 ## Configuration
 
-| Variable          | Default        | Description                                     |
-|-------------------|----------------|-------------------------------------------------|
-| PORT              | 8084           | worker+web バイナリの HTTP ポート               |
-| DATABASE_DSN      | admin.db       | SQLite データベースファイルパス                 |
-| LOG_DIR           | ./data/logs    | jsonl ログの出力先ディレクトリ                  |
-| WORKER_INTERVAL   | 15s            | worker デーモンの実行間隔                       |
-| SHUTDOWN_TIMEOUT  | 10s            | graceful shutdown のタイムアウト                |
+設定は 2 層に分かれる。**env（インフラ。読み取り専用）** と **toml ファイル（実行時調整値。Config 画面から編集可）**。
+
+### env（読み取り専用）
+
+| Variable     | Default       | Description                                  |
+|--------------|---------------|----------------------------------------------|
+| PORT         | 8084          | worker+web バイナリの HTTP ポート            |
+| DATABASE_DSN | admin.db      | SQLite データベースファイルパス              |
+| LOG_DIR      | ./data/logs   | jsonl ログの出力先ディレクトリ               |
+| CONFIG_FILE  | config.toml   | 編集可能設定の toml ファイルパス             |
+
+### toml ファイル（編集可。`config.toml`）
+
+初回起動時に既定値で自動生成される。Config 画面のフォームから編集 → 保存（`PUT /api/config`）→
+**Restart & apply**（`POST /api/restart`）で worker+web が in-process で再起動し反映される。
+保存しただけでは実行中の設定は変わらない（再起動で適用）。
+
+| Key              | Default | Description                      |
+|------------------|---------|----------------------------------|
+| worker_interval  | 15s     | worker デーモンの実行間隔         |
+| shutdown_timeout | 10s     | graceful shutdown のタイムアウト  |
+
+```toml
+# config.toml
+worker_interval = "15s"
+shutdown_timeout = "10s"
+```
 
 ## Scaffolding
 

--- a/go-react-admin/cmd/server/main.go
+++ b/go-react-admin/cmd/server/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -62,5 +63,14 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return enc.Encode(cfg)
 	}
 
-	return server.Run(ctx)
+	// Run until a real stop. A restart request (POST /api/restart) returns
+	// ErrRestart; loop so the editable toml config is reloaded in-process,
+	// rather than exiting. SIGINT/SIGTERM cancels ctx → Run returns nil → exit.
+	for {
+		err := server.Run(ctx)
+		if errors.Is(err, server.ErrRestart) && ctx.Err() == nil {
+			continue
+		}
+		return err
+	}
 }

--- a/go-react-admin/frontend/src/api/config.test.ts
+++ b/go-react-admin/frontend/src/api/config.test.ts
@@ -2,10 +2,25 @@ import { describe, it, expect } from "vitest";
 import { configApi } from "./config";
 
 describe("configApi", () => {
-  it("fetches and validates config", async () => {
+  it("fetches and validates config items with their source", async () => {
     const cfg = await configApi.get();
-    expect(cfg.port).toBe("8080");
-    expect(cfg.worker_interval).toBe(30);
-    expect(cfg.shutdown_timeout).toBe(10);
+    expect(cfg.configPath).toBe("config.toml");
+
+    const byKey = Object.fromEntries(cfg.items.map((i) => [i.key, i]));
+    expect(byKey["port"].source).toBe("env");
+    expect(byKey["port"].editable).toBe(false);
+    expect(byKey["worker_interval"].source).toBe("toml");
+    expect(byKey["worker_interval"].editable).toBe(true);
+    expect(byKey["worker_interval"].value).toBe("30s");
+  });
+
+  it("updates editable settings and reports restart is required", async () => {
+    const res = await configApi.update({ worker_interval: "45s" });
+    expect(res.workerInterval).toBe("45s");
+    expect(res.restartRequired).toBe(true);
+  });
+
+  it("posts a restart request", async () => {
+    await expect(configApi.restart()).resolves.toBeUndefined();
   });
 });

--- a/go-react-admin/frontend/src/api/config.ts
+++ b/go-react-admin/frontend/src/api/config.ts
@@ -1,10 +1,27 @@
 import { apiClient } from "./client";
-import { configResponseSchema } from "@/schemas/run";
-import type { ConfigResponse } from "@/types/run";
+import { configResponseSchema, updateConfigResponseSchema } from "@/schemas/run";
+import type {
+  ConfigResponse,
+  UpdateConfigInput,
+  UpdateConfigResponse,
+} from "@/types/run";
 
 export const configApi = {
   get: async (): Promise<ConfigResponse> => {
     const json = await apiClient.get("api/config").json();
     return configResponseSchema.parse(json);
+  },
+
+  // update persists the editable (toml) settings. The change is NOT applied to
+  // the running process until restart() is called.
+  update: async (input: UpdateConfigInput): Promise<UpdateConfigResponse> => {
+    const json = await apiClient.put("api/config", { json: input }).json();
+    return updateConfigResponseSchema.parse(json);
+  },
+
+  // restart asks the server to reload its config. The process drops the current
+  // connection while it comes back up.
+  restart: async (): Promise<void> => {
+    await apiClient.post("api/restart");
   },
 };

--- a/go-react-admin/frontend/src/hooks/useConfig.ts
+++ b/go-react-admin/frontend/src/hooks/useConfig.ts
@@ -1,9 +1,28 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { configApi } from "@/api/config";
+import type { UpdateConfigInput } from "@/types/run";
 
 export function useConfig() {
   return useQuery({
     queryKey: ["config"],
     queryFn: () => configApi.get(),
+  });
+}
+
+// useUpdateConfig persists edited toml settings (applied on restart).
+export function useUpdateConfig() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateConfigInput) => configApi.update(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["config"] });
+    },
+  });
+}
+
+// useRestart triggers a server restart so saved toml values take effect.
+export function useRestart() {
+  return useMutation({
+    mutationFn: () => configApi.restart(),
   });
 }

--- a/go-react-admin/frontend/src/pages/ConfigPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/ConfigPage.test.tsx
@@ -1,15 +1,38 @@
 import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
 import { render, screen, waitFor } from "@/test/test-utils";
 import { ConfigPage } from "./ConfigPage";
 
 describe("ConfigPage", () => {
-  it("renders config as key/value rows", async () => {
+  it("shows env values read-only and toml values as editable inputs", async () => {
     render(<ConfigPage />);
 
+    // env value is rendered as static text (read-only)
     await waitFor(() => {
       expect(screen.getByText("file:admin.db")).toBeInTheDocument();
     });
-    expect(screen.getByText("/var/log/admin")).toBeInTheDocument();
-    expect(screen.getByText("Worker interval (s)")).toBeInTheDocument();
+
+    // both env and toml source badges are present
+    expect(screen.getAllByText("env").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("toml").length).toBeGreaterThan(0);
+
+    // editable toml value is rendered as an input seeded with the server value
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs.some((el) => (el as HTMLInputElement).value === "30s")).toBe(true);
+  });
+
+  it("saves edited toml and reveals the restart banner", async () => {
+    const user = userEvent.setup();
+    render(<ConfigPage />);
+
+    const input = await screen.findByDisplayValue("30s");
+    await user.clear(input);
+    await user.type(input, "45s");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Restart/ })).toBeInTheDocument();
+    });
   });
 });

--- a/go-react-admin/frontend/src/pages/ConfigPage.tsx
+++ b/go-react-admin/frontend/src/pages/ConfigPage.tsx
@@ -1,50 +1,182 @@
-import { DataTable } from "@/components/admin/data-table";
-import { useConfig } from "@/hooks/useConfig";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { KindBadge } from "@/components/admin/kind-badge";
+import { useConfig, useRestart, useUpdateConfig } from "@/hooks/useConfig";
+import type { ConfigItem, UpdateConfigInput } from "@/types/run";
 
-interface ConfigRow {
-  key: string;
-  value: string;
+// SourceBadge tags a setting with where it comes from. env = read-only,
+// toml = editable from this screen.
+function SourceBadge({ source }: { source: ConfigItem["source"] }) {
+  return source === "env" ? (
+    <KindBadge label="env" color="#64748b" />
+  ) : (
+    <KindBadge label="toml" color="#4f46e5" />
+  );
 }
 
 export function ConfigPage() {
   const { data, isLoading, isError, error } = useConfig();
+  const updateConfig = useUpdateConfig();
+  const restart = useRestart();
 
-  const rows: ConfigRow[] = data
-    ? [
-        { key: "Port", value: data.port },
-        { key: "Database DSN", value: data.database_dsn },
-        { key: "Log directory", value: data.log_dir },
-        { key: "Worker interval (s)", value: String(data.worker_interval) },
-        { key: "Shutdown timeout (s)", value: String(data.shutdown_timeout) },
-      ]
-    : [];
+  // Track only the user's edits (keyed by setting). The displayed value is the
+  // edit if present, otherwise the server value — so no effect-based seeding is
+  // needed, and a refetch after save naturally shows the persisted values.
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+
+  const editableItems = data?.items.filter((i) => i.editable) ?? [];
+  const envItems = data?.items.filter((i) => !i.editable) ?? [];
+  const dirty = Object.keys(edits).length > 0;
+
+  const valueFor = (key: string, fallback: string) => edits[key] ?? fallback;
+
+  const onChange = (key: string, value: string) => {
+    setEdits((prev) => ({ ...prev, [key]: value }));
+    setSaved(false);
+  };
+
+  const onSave = () => {
+    const input: UpdateConfigInput = {
+      worker_interval: edits["worker_interval"],
+      shutdown_timeout: edits["shutdown_timeout"],
+    };
+    updateConfig.mutate(input, {
+      onSuccess: () => {
+        setEdits({});
+        setSaved(true);
+      },
+    });
+  };
+
+  // Restart, then poll /health until the server is back, then reload the page so
+  // the freshly-applied config is shown.
+  const onRestart = () => {
+    setRestarting(true);
+    restart.mutate(undefined, {
+      onSuccess: async () => {
+        await waitForHealth();
+        window.location.reload();
+      },
+      onError: () => setRestarting(false),
+    });
+  };
 
   return (
-    <div className="flex flex-col gap-4">
-      <h1 className="text-xl font-semibold">Config</h1>
+    <div className="flex max-w-3xl flex-col gap-6">
+      <div>
+        <h1 className="text-xl font-semibold">Config</h1>
+        {data?.configPath && (
+          <p className="mt-1 text-sm text-slate-500">
+            Editable values are stored in{" "}
+            <span className="font-mono text-xs">{data.configPath}</span> and applied on
+            restart.
+          </p>
+        )}
+      </div>
 
-      {isError ? (
+      {isError && (
         <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
           Failed to load config: {(error as Error)?.message}
         </div>
-      ) : (
-        <DataTable<ConfigRow>
-          columns={[
-            {
-              header: "Key",
-              cell: (row) => <span className="font-medium">{row.key}</span>,
-              className: "w-1/3",
-            },
-            {
-              header: "Value",
-              cell: (row) => <span className="font-mono text-xs">{row.value}</span>,
-            },
-          ]}
-          rows={rows}
-          getRowKey={(row) => row.key}
-          emptyMessage={isLoading ? "Loading…" : "No config"}
-        />
+      )}
+      {isLoading && <p className="text-sm text-slate-500">Loading…</p>}
+
+      {/* Environment — read-only */}
+      {envItems.length > 0 && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold text-slate-700">
+            Environment (read-only)
+          </h2>
+          <div className="overflow-hidden rounded-md border border-slate-200">
+            {envItems.map((item) => (
+              <div
+                key={item.key}
+                className="flex items-center justify-between gap-4 border-b border-slate-100 bg-slate-50 px-3 py-2 last:border-b-0"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-slate-700">{item.label}</span>
+                  <SourceBadge source={item.source} />
+                </div>
+                <span className="font-mono text-xs text-slate-600">{item.value}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* File (toml) — editable */}
+      {editableItems.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold text-slate-700">File (editable)</h2>
+          <div className="flex flex-col gap-3 rounded-md border border-slate-200 p-3">
+            {editableItems.map((item) => (
+              <label key={item.key} className="flex items-center justify-between gap-4">
+                <span className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-slate-700">{item.label}</span>
+                  <SourceBadge source={item.source} />
+                </span>
+                <input
+                  className="w-40 rounded-md border border-slate-300 px-2 py-1 text-right font-mono text-sm focus:border-indigo-400 focus:outline-none"
+                  value={valueFor(item.key, item.value)}
+                  onChange={(e) => onChange(item.key, e.target.value)}
+                />
+              </label>
+            ))}
+
+            <p className="text-xs text-slate-400">
+              Durations use Go syntax, e.g. <span className="font-mono">15s</span>,{" "}
+              <span className="font-mono">2m</span>.
+            </p>
+
+            {updateConfig.isError && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                {(updateConfig.error as Error)?.message ?? "Failed to save"}
+              </div>
+            )}
+
+            <div className="flex items-center gap-3">
+              <Button onClick={onSave} disabled={!dirty || updateConfig.isPending}>
+                {updateConfig.isPending ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Restart banner — shown once a save lands, since changes need a restart */}
+      {saved && (
+        <div className="flex items-center justify-between gap-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-3">
+          <span className="text-sm text-amber-800">
+            Saved. Restart to apply the new values to the running server.
+          </span>
+          <Button variant="default" onClick={onRestart} disabled={restarting}>
+            {restarting ? "Restarting…" : "Restart & apply"}
+          </Button>
+        </div>
       )}
     </div>
   );
+}
+
+// waitForHealth polls /health until the restarted server responds (or times out).
+async function waitForHealth(timeoutMs = 15000): Promise<void> {
+  const base = import.meta.env.VITE_API_BASE_URL ?? "";
+  const deadline = Date.now() + timeoutMs;
+  // Give the old process a moment to drop before polling.
+  await sleep(500);
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${base}/health`, { cache: "no-store" });
+      if (res.ok) return;
+    } catch {
+      // server still down; keep polling
+    }
+    await sleep(500);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/go-react-admin/frontend/src/schemas/run.ts
+++ b/go-react-admin/frontend/src/schemas/run.ts
@@ -68,10 +68,23 @@ export const metricsAggregateResponseSchema = z.object({
   series: z.array(metricSeriesSchema),
 });
 
+export const configSourceSchema = z.enum(["env", "toml"]);
+
+export const configItemSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  value: z.string(),
+  source: configSourceSchema,
+  editable: z.boolean(),
+});
+
 export const configResponseSchema = z.object({
-  port: z.string(),
-  database_dsn: z.string(),
-  log_dir: z.string(),
-  worker_interval: z.number(),
-  shutdown_timeout: z.number(),
+  configPath: z.string(),
+  items: z.array(configItemSchema),
+});
+
+export const updateConfigResponseSchema = z.object({
+  workerInterval: z.string(),
+  shutdownTimeout: z.string(),
+  restartRequired: z.boolean(),
 });

--- a/go-react-admin/frontend/src/test/mocks/handlers.ts
+++ b/go-react-admin/frontend/src/test/mocks/handlers.ts
@@ -116,11 +116,38 @@ export const mockMetrics: MetricsAggregateResponse = {
 };
 
 export const mockConfig: ConfigResponse = {
-  port: "8080",
-  database_dsn: "file:admin.db",
-  log_dir: "/var/log/admin",
-  worker_interval: 30,
-  shutdown_timeout: 10,
+  configPath: "config.toml",
+  items: [
+    { key: "port", label: "Port", value: "8084", source: "env", editable: false },
+    {
+      key: "database_dsn",
+      label: "Database DSN",
+      value: "file:admin.db",
+      source: "env",
+      editable: false,
+    },
+    {
+      key: "log_dir",
+      label: "Log directory",
+      value: "/var/log/admin",
+      source: "env",
+      editable: false,
+    },
+    {
+      key: "worker_interval",
+      label: "Worker interval",
+      value: "30s",
+      source: "toml",
+      editable: true,
+    },
+    {
+      key: "shutdown_timeout",
+      label: "Shutdown timeout",
+      value: "10s",
+      source: "toml",
+      editable: true,
+    },
+  ],
 };
 
 export const handlers = [
@@ -151,5 +178,21 @@ export const handlers = [
 
   http.get("*/api/config", () => {
     return HttpResponse.json(mockConfig);
+  }),
+
+  http.put("*/api/config", async ({ request }) => {
+    const body = (await request.json()) as {
+      worker_interval?: string;
+      shutdown_timeout?: string;
+    };
+    return HttpResponse.json({
+      workerInterval: body.worker_interval ?? "30s",
+      shutdownTimeout: body.shutdown_timeout ?? "10s",
+      restartRequired: true,
+    });
+  }),
+
+  http.post("*/api/restart", () => {
+    return HttpResponse.json({ status: "restarting" }, { status: 202 });
   }),
 ];

--- a/go-react-admin/frontend/src/types/run.ts
+++ b/go-react-admin/frontend/src/types/run.ts
@@ -10,7 +10,9 @@ import type {
   runsResponseSchema,
   runDetailResponseSchema,
   metricsAggregateResponseSchema,
+  configItemSchema,
   configResponseSchema,
+  updateConfigResponseSchema,
 } from "@/schemas/run";
 
 export type RunStatus = z.infer<typeof runStatusSchema>;
@@ -23,4 +25,11 @@ export type MetricSeries = z.infer<typeof metricSeriesSchema>;
 export type RunsResponse = z.infer<typeof runsResponseSchema>;
 export type RunDetailResponse = z.infer<typeof runDetailResponseSchema>;
 export type MetricsAggregateResponse = z.infer<typeof metricsAggregateResponseSchema>;
+export type ConfigItem = z.infer<typeof configItemSchema>;
 export type ConfigResponse = z.infer<typeof configResponseSchema>;
+export type UpdateConfigResponse = z.infer<typeof updateConfigResponseSchema>;
+
+export interface UpdateConfigInput {
+  worker_interval?: string;
+  shutdown_timeout?: string;
+}

--- a/go-react-admin/go.mod
+++ b/go-react-admin/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/lmittmann/tint v1.1.3
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.19.1
 	github.com/sethvargo/go-envconfig v1.3.0
 	golang.org/x/sync v0.20.0
@@ -33,7 +34,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go-react-admin/internal/config/config.go
+++ b/go-react-admin/internal/config/config.go
@@ -1,33 +1,153 @@
-// Package config loads runtime configuration from the environment.
+// Package config loads runtime configuration from two layers:
 //
-// Configuration is env-only (envconfig, consistent with the other Go
-// templates). The binary exposes just --version / --config flags; there is no
-// cobra subcommand tree.
+//   - env (read-only): infrastructure that can't safely change without an
+//     operator — Port, DatabaseDSN, LogDir, ConfigFile path.
+//   - toml file (editable): runtime-tunable knobs the admin console can edit
+//     and apply via a restart — WorkerInterval, ShutdownTimeout.
+//
+// The split lets the Config screen show which values come from where, keep env
+// values immutable, and let the file-backed values be edited + reloaded on
+// restart. The binary still exposes only --version / --config flags.
 package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/sethvargo/go-envconfig"
 )
 
-// Config is the resolved runtime configuration. It is safe to print via
-// `server --config`; no secrets are stored here.
-type Config struct {
-	Port            string        `env:"PORT, default=8084" json:"port"`
-	DatabaseDSN     string        `env:"DATABASE_DSN, default=admin.db" json:"database_dsn"`
-	LogDir          string        `env:"LOG_DIR, default=./data/logs" json:"log_dir"`
-	WorkerInterval  time.Duration `env:"WORKER_INTERVAL, default=15s" json:"worker_interval"`
-	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT, default=10s" json:"shutdown_timeout"`
+// envConfig holds the environment-sourced, read-only settings.
+type envConfig struct {
+	Port        string `env:"PORT, default=8084"`
+	DatabaseDSN string `env:"DATABASE_DSN, default=admin.db"`
+	LogDir      string `env:"LOG_DIR, default=./data/logs"`
+	ConfigFile  string `env:"CONFIG_FILE, default=config.toml"`
 }
 
-// Load reads configuration from the environment, applying struct-tag defaults.
+// FileConfig is the toml-file-sourced, editable settings. Durations are stored
+// as Go duration strings (e.g. "15s") so the file stays human-editable.
+type FileConfig struct {
+	WorkerInterval  string `toml:"worker_interval"`
+	ShutdownTimeout string `toml:"shutdown_timeout"`
+}
+
+// Defaults for the file-backed settings, used when the toml file or a key is
+// absent.
+const (
+	defaultWorkerInterval  = "15s"
+	defaultShutdownTimeout = "10s"
+)
+
+// Config is the fully resolved runtime configuration.
+type Config struct {
+	// env-sourced (read-only)
+	Port        string `json:"port"`
+	DatabaseDSN string `json:"database_dsn"`
+	LogDir      string `json:"log_dir"`
+	ConfigFile  string `json:"config_file"`
+
+	// file-sourced (editable), resolved to durations
+	WorkerInterval  time.Duration `json:"worker_interval"`
+	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
+}
+
+// Load resolves configuration: env for infrastructure, then the toml file for
+// the editable runtime knobs. A missing toml file is not an error — defaults
+// apply (and EnsureFile can materialize it for first-time editing).
 func Load(ctx context.Context) (Config, error) {
-	var c Config
-	if err := envconfig.Process(ctx, &c); err != nil {
-		return Config{}, fmt.Errorf("load config: %w", err)
+	var ec envConfig
+	if err := envconfig.Process(ctx, &ec); err != nil {
+		return Config{}, fmt.Errorf("load env config: %w", err)
 	}
-	return c, nil
+
+	fc, err := ReadFile(ec.ConfigFile)
+	if err != nil {
+		return Config{}, err
+	}
+
+	workerInterval, err := time.ParseDuration(fc.WorkerInterval)
+	if err != nil {
+		return Config{}, fmt.Errorf("config %s: worker_interval %q: %w", ec.ConfigFile, fc.WorkerInterval, err)
+	}
+	shutdownTimeout, err := time.ParseDuration(fc.ShutdownTimeout)
+	if err != nil {
+		return Config{}, fmt.Errorf("config %s: shutdown_timeout %q: %w", ec.ConfigFile, fc.ShutdownTimeout, err)
+	}
+
+	return Config{
+		Port:            ec.Port,
+		DatabaseDSN:     ec.DatabaseDSN,
+		LogDir:          ec.LogDir,
+		ConfigFile:      ec.ConfigFile,
+		WorkerInterval:  workerInterval,
+		ShutdownTimeout: shutdownTimeout,
+	}, nil
+}
+
+// ReadFile reads the toml file, falling back to defaults for a missing file or
+// any unset key. The returned FileConfig always has both fields populated.
+func ReadFile(path string) (FileConfig, error) {
+	fc := FileConfig{WorkerInterval: defaultWorkerInterval, ShutdownTimeout: defaultShutdownTimeout}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fc, nil
+		}
+		return FileConfig{}, fmt.Errorf("read config file %s: %w", path, err)
+	}
+
+	var parsed FileConfig
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		return FileConfig{}, fmt.Errorf("parse config file %s: %w", path, err)
+	}
+	if parsed.WorkerInterval != "" {
+		fc.WorkerInterval = parsed.WorkerInterval
+	}
+	if parsed.ShutdownTimeout != "" {
+		fc.ShutdownTimeout = parsed.ShutdownTimeout
+	}
+	return fc, nil
+}
+
+// WriteFile validates the durations and writes the toml file atomically. It
+// does not affect the running process — changes apply on the next restart.
+func WriteFile(path string, fc FileConfig) error {
+	if _, err := time.ParseDuration(fc.WorkerInterval); err != nil {
+		return fmt.Errorf("worker_interval %q: %w", fc.WorkerInterval, err)
+	}
+	if _, err := time.ParseDuration(fc.ShutdownTimeout); err != nil {
+		return fmt.Errorf("shutdown_timeout %q: %w", fc.ShutdownTimeout, err)
+	}
+
+	data, err := toml.Marshal(fc)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	header := "# go-react-admin runtime config (editable from the admin console).\n" +
+		"# Ports and paths are configured via environment variables instead.\n\n"
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append([]byte(header), data...), 0o644); err != nil {
+		return fmt.Errorf("write config file %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace config file %s: %w", path, err)
+	}
+	return nil
+}
+
+// EnsureFile creates the toml file with current values if it does not exist, so
+// the admin console always has a concrete file to edit.
+func EnsureFile(path string, fc FileConfig) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat config file %s: %w", path, err)
+	}
+	return WriteFile(path, fc)
 }

--- a/go-react-admin/internal/config/config_test.go
+++ b/go-react-admin/internal/config/config_test.go
@@ -2,11 +2,16 @@ package config
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
 func TestLoad_Defaults(t *testing.T) {
+	// Point CONFIG_FILE at a non-existent path so file defaults apply.
+	t.Setenv("CONFIG_FILE", filepath.Join(t.TempDir(), "absent.toml"))
+
 	cfg, err := Load(context.Background())
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
@@ -15,23 +20,16 @@ func TestLoad_Defaults(t *testing.T) {
 		t.Errorf("Port = %q, want 8084", cfg.Port)
 	}
 	if cfg.WorkerInterval != 15*time.Second {
-		t.Errorf("WorkerInterval = %v, want 15s", cfg.WorkerInterval)
+		t.Errorf("WorkerInterval = %v, want 15s (file default)", cfg.WorkerInterval)
 	}
 	if cfg.ShutdownTimeout != 10*time.Second {
-		t.Errorf("ShutdownTimeout = %v, want 10s", cfg.ShutdownTimeout)
-	}
-}
-
-func TestLoad_InvalidDurationReturnsError(t *testing.T) {
-	t.Setenv("WORKER_INTERVAL", "not-a-duration")
-	if _, err := Load(context.Background()); err == nil {
-		t.Error("Load() with invalid duration = nil error, want error")
+		t.Errorf("ShutdownTimeout = %v, want 10s (file default)", cfg.ShutdownTimeout)
 	}
 }
 
 func TestLoad_EnvOverride(t *testing.T) {
 	t.Setenv("PORT", "9999")
-	t.Setenv("WORKER_INTERVAL", "2s")
+	t.Setenv("CONFIG_FILE", filepath.Join(t.TempDir(), "absent.toml"))
 	cfg, err := Load(context.Background())
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
@@ -39,7 +37,101 @@ func TestLoad_EnvOverride(t *testing.T) {
 	if cfg.Port != "9999" {
 		t.Errorf("Port = %q, want 9999", cfg.Port)
 	}
+}
+
+func TestLoad_FromTomlFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := WriteFile(path, FileConfig{WorkerInterval: "2s", ShutdownTimeout: "30s"}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("CONFIG_FILE", path)
+
+	cfg, err := Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
 	if cfg.WorkerInterval != 2*time.Second {
-		t.Errorf("WorkerInterval = %v, want 2s", cfg.WorkerInterval)
+		t.Errorf("WorkerInterval = %v, want 2s (from toml)", cfg.WorkerInterval)
+	}
+	if cfg.ShutdownTimeout != 30*time.Second {
+		t.Errorf("ShutdownTimeout = %v, want 30s (from toml)", cfg.ShutdownTimeout)
+	}
+}
+
+func TestLoad_InvalidDurationInFileReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(`worker_interval = "not-a-duration"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONFIG_FILE", path)
+	if _, err := Load(context.Background()); err == nil {
+		t.Error("Load() with invalid toml duration = nil error, want error")
+	}
+}
+
+func TestWriteFile_RejectsInvalidDuration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := WriteFile(path, FileConfig{WorkerInterval: "nope", ShutdownTimeout: "10s"}); err == nil {
+		t.Error("WriteFile with invalid duration = nil, want error")
+	}
+}
+
+func TestWriteFile_UnwritablePathReturnsError(t *testing.T) {
+	// Parent directory does not exist → the temp write fails.
+	path := filepath.Join(t.TempDir(), "missing-dir", "config.toml")
+	if err := WriteFile(path, FileConfig{WorkerInterval: "1s", ShutdownTimeout: "1s"}); err == nil {
+		t.Error("WriteFile to nonexistent dir = nil, want error")
+	}
+}
+
+func TestReadFile_InvalidTomlReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.toml")
+	if err := os.WriteFile(path, []byte("= = not valid toml ="), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFile(path); err == nil {
+		t.Error("ReadFile(invalid toml) = nil, want parse error")
+	}
+}
+
+func TestReadFile_MissingReturnsDefaults(t *testing.T) {
+	fc, err := ReadFile(filepath.Join(t.TempDir(), "absent.toml"))
+	if err != nil {
+		t.Fatalf("ReadFile(missing): %v", err)
+	}
+	if fc.WorkerInterval != defaultWorkerInterval || fc.ShutdownTimeout != defaultShutdownTimeout {
+		t.Errorf("defaults not applied: %+v", fc)
+	}
+}
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := WriteFile(path, FileConfig{WorkerInterval: "7s", ShutdownTimeout: "12s"}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fc, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if fc.WorkerInterval != "7s" || fc.ShutdownTimeout != "12s" {
+		t.Errorf("round trip mismatch: %+v", fc)
+	}
+}
+
+func TestEnsureFile_CreatesWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := EnsureFile(path, FileConfig{WorkerInterval: "15s", ShutdownTimeout: "10s"}); err != nil {
+		t.Fatalf("EnsureFile: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("EnsureFile did not create file: %v", err)
+	}
+	// A second call must not error or overwrite.
+	if err := EnsureFile(path, FileConfig{WorkerInterval: "99s", ShutdownTimeout: "99s"}); err != nil {
+		t.Fatalf("EnsureFile (existing): %v", err)
+	}
+	fc, _ := ReadFile(path)
+	if fc.WorkerInterval != "15s" {
+		t.Errorf("EnsureFile overwrote existing file: %+v", fc)
 	}
 }

--- a/go-react-admin/internal/server/server.go
+++ b/go-react-admin/internal/server/server.go
@@ -33,15 +33,29 @@ import (
 // timeline. Kept small so a fresh install fills the console quickly.
 const perPhaseDelay = 300 * time.Millisecond
 
+// ErrRestart is returned by Run when the admin console requested a restart
+// (POST /api/restart). main() treats it as "reload": it calls Run again so the
+// editable toml config is re-read, instead of exiting the process.
+var ErrRestart = errors.New("restart requested")
+
 // Run boots the worker daemon and the web server in one process and blocks
-// until ctx is canceled (graceful shutdown, returns nil) or one of the
-// components returns a fatal error (returns that error).
+// until ctx is canceled (graceful shutdown, returns nil), a restart is
+// requested (returns ErrRestart), or a component fails (returns that error).
 func Run(ctx context.Context) error {
 	setupLogger()
 
 	cfg, err := config.Load(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Materialize the toml file on first boot so the console always has a
+	// concrete file to edit. Failure here is non-fatal (e.g. read-only FS).
+	if ferr := config.EnsureFile(cfg.ConfigFile, config.FileConfig{
+		WorkerInterval:  cfg.WorkerInterval.String(),
+		ShutdownTimeout: cfg.ShutdownTimeout.String(),
+	}); ferr != nil {
+		slog.Warn("could not materialize config file", "path", cfg.ConfigFile, "error", ferr)
 	}
 
 	if os.Getenv("APP_ENV") == "production" {
@@ -63,11 +77,22 @@ func Run(ctx context.Context) error {
 
 	wrk := worker.New(cfg.WorkerInterval, perPhaseDelay, st, logs, metrics)
 
+	// requestRestart is invoked by the web handler (POST /api/restart). It is
+	// non-blocking and idempotent within a single boot.
+	restartCh := make(chan struct{}, 1)
+	requestRestart := func() {
+		select {
+		case restartCh <- struct{}{}:
+		default:
+		}
+	}
+
 	handler := web.New(web.Deps{
-		Store:   st,
-		Logs:    logs,
-		Metrics: metrics,
-		Config:  cfg,
+		Store:          st,
+		Logs:           logs,
+		Metrics:        metrics,
+		Config:         cfg,
+		RequestRestart: requestRestart,
 	}).Routes(static.Handler())
 
 	srv := &http.Server{
@@ -79,6 +104,18 @@ func Run(ctx context.Context) error {
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
+
+	// Restart watcher: a restart request returns ErrRestart, which cancels gctx
+	// (via errgroup) and tears down the worker + web for a clean reload.
+	g.Go(func() error {
+		select {
+		case <-gctx.Done():
+			return nil
+		case <-restartCh:
+			slog.Info("restart requested; reloading config")
+			return ErrRestart
+		}
+	})
 
 	// Worker daemon: runs until gctx is canceled.
 	g.Go(func() error {

--- a/go-react-admin/internal/server/server_test.go
+++ b/go-react-admin/internal/server/server_test.go
@@ -2,26 +2,34 @@ package server
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
+
+func setTempEnv(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("DATABASE_DSN", filepath.Join(dir, "server.db"))
+	t.Setenv("LOG_DIR", filepath.Join(dir, "logs"))
+	t.Setenv("CONFIG_FILE", filepath.Join(dir, "config.toml"))
+}
 
 // TestRun_GracefulShutdown verifies that Run starts the worker + web server and
 // returns nil once the context is canceled (SIGINT/SIGTERM equivalent).
 func TestRun_GracefulShutdown(t *testing.T) {
 	t.Setenv("PORT", "0") // random free port, avoids collisions in CI
-	t.Setenv("WORKER_INTERVAL", "10ms")
-	t.Setenv("SHUTDOWN_TIMEOUT", "2s")
-	t.Setenv("DATABASE_DSN", filepath.Join(t.TempDir(), "server.db"))
-	t.Setenv("LOG_DIR", filepath.Join(t.TempDir(), "logs"))
+	setTempEnv(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
 	go func() { done <- Run(ctx) }()
 
-	// Give the components a moment to come up, then signal shutdown.
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 
@@ -33,4 +41,69 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run() did not return after context cancel")
 	}
+}
+
+// TestRun_RestartViaAPI verifies the full restart pathway: POST /api/restart
+// makes Run tear down and return ErrRestart (which main() loops on to reload).
+func TestRun_RestartViaAPI(t *testing.T) {
+	port := freePort(t)
+	t.Setenv("PORT", port)
+	setTempEnv(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx) }()
+
+	base := "http://127.0.0.1:" + port
+	waitFor(t, base+"/health")
+
+	resp, err := http.Post(base+"/api/restart", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /api/restart: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("restart status = %d, want 202", resp.StatusCode)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrRestart) {
+			t.Errorf("Run() = %v, want ErrRestart", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return ErrRestart after /api/restart")
+	}
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr is not *net.TCPAddr: %T", ln.Addr())
+	}
+	return strconv.Itoa(addr.Port)
+}
+
+func waitFor(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server did not become ready at %s", url)
 }

--- a/go-react-admin/internal/web/web.go
+++ b/go-react-admin/internal/web/web.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"go-react-admin/internal/config"
 	"go-react-admin/internal/observability"
 	"go-react-admin/internal/persistlog"
 	"go-react-admin/internal/store"
@@ -20,10 +21,11 @@ import (
 
 // Deps are the runtime dependencies of the web server.
 type Deps struct {
-	Store   *store.Store
-	Logs    *persistlog.Writer
-	Metrics *observability.Metrics
-	Config  any // returned verbatim by GET /api/config
+	Store          *store.Store
+	Logs           *persistlog.Writer
+	Metrics        *observability.Metrics
+	RequestRestart func()
+	Config         config.Config
 }
 
 // Server holds the handler dependencies.
@@ -51,6 +53,8 @@ func (s *Server) Routes(staticHandler http.Handler) http.Handler {
 		api.GET("/runs/:id", s.getRun)
 		api.GET("/metrics/aggregate", s.metricsAggregate)
 		api.GET("/config", s.getConfig)
+		api.PUT("/config", s.updateConfig)
+		api.POST("/restart", s.restart)
 	}
 
 	r.NoRoute(gin.WrapH(staticHandler))
@@ -182,8 +186,83 @@ func (s *Server) metricsAggregate(c *gin.Context) {
 	c.JSON(http.StatusOK, metricsAggregateResponse{From: from, To: to, Bucket: bucketStr, Series: series})
 }
 
+// configItem is one setting shown on the Config screen, tagged with its source
+// so the UI can render env values read-only and toml values as editable.
+type configItem struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Value    string `json:"value"`
+	Source   string `json:"source"`   // "env" | "toml"
+	Editable bool   `json:"editable"` // env: false, toml: true
+}
+
+type configResponse struct {
+	ConfigPath string       `json:"configPath"`
+	Items      []configItem `json:"items"`
+}
+
 func (s *Server) getConfig(c *gin.Context) {
-	c.JSON(http.StatusOK, s.deps.Config)
+	cfg := s.deps.Config
+	c.JSON(http.StatusOK, configResponse{
+		ConfigPath: cfg.ConfigFile,
+		Items: []configItem{
+			{Key: "port", Label: "Port", Value: cfg.Port, Source: "env", Editable: false},
+			{Key: "database_dsn", Label: "Database DSN", Value: cfg.DatabaseDSN, Source: "env", Editable: false},
+			{Key: "log_dir", Label: "Log directory", Value: cfg.LogDir, Source: "env", Editable: false},
+			{Key: "worker_interval", Label: "Worker interval", Value: cfg.WorkerInterval.String(), Source: "toml", Editable: true},
+			{Key: "shutdown_timeout", Label: "Shutdown timeout", Value: cfg.ShutdownTimeout.String(), Source: "toml", Editable: true},
+		},
+	})
+}
+
+type updateConfigRequest struct {
+	WorkerInterval  string `json:"worker_interval"`
+	ShutdownTimeout string `json:"shutdown_timeout"`
+}
+
+// updateConfig persists the editable (toml) settings. Env settings are not
+// accepted here. Changes take effect on the next restart (POST /api/restart),
+// not immediately — the response says so via "restartRequired".
+func (s *Server) updateConfig(c *gin.Context) {
+	var req updateConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	// Start from the current file so a partial update keeps the other value.
+	current, err := config.ReadFile(s.deps.Config.ConfigFile)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if req.WorkerInterval != "" {
+		current.WorkerInterval = req.WorkerInterval
+	}
+	if req.ShutdownTimeout != "" {
+		current.ShutdownTimeout = req.ShutdownTimeout
+	}
+
+	if err := config.WriteFile(s.deps.Config.ConfigFile, current); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"workerInterval":  current.WorkerInterval,
+		"shutdownTimeout": current.ShutdownTimeout,
+		"restartRequired": true,
+	})
+}
+
+// restart triggers a graceful restart so saved toml values are reloaded.
+func (s *Server) restart(c *gin.Context) {
+	if s.deps.RequestRestart == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "restart not supported"})
+		return
+	}
+	s.deps.RequestRestart()
+	c.JSON(http.StatusAccepted, gin.H{"status": "restarting"})
 }
 
 func atoiDefault(s string, def int) int {

--- a/go-react-admin/internal/web/web_test.go
+++ b/go-react-admin/internal/web/web_test.go
@@ -6,11 +6,13 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"go-react-admin/internal/config"
 	"go-react-admin/internal/observability"
 	"go-react-admin/internal/persistlog"
 	"go-react-admin/internal/store"
@@ -49,7 +51,11 @@ func newTestServer(t *testing.T) (http.Handler, int64) {
 		Store:   st,
 		Logs:    logs,
 		Metrics: observability.New(),
-		Config:  map[string]string{"port": "8080"},
+		Config: config.Config{
+			Port: "8084", DatabaseDSN: "admin.db", LogDir: "data/logs",
+			ConfigFile:     filepath.Join(t.TempDir(), "config.toml"),
+			WorkerInterval: 15 * time.Second, ShutdownTimeout: 10 * time.Second,
+		},
 	}).Routes(staticStub())
 	return h, run.ID
 }
@@ -153,11 +159,102 @@ func TestMetricsAggregate_BadBucket(t *testing.T) {
 	}
 }
 
-func TestConfig(t *testing.T) {
+func TestConfig_TagsEnvAndTomlSources(t *testing.T) {
 	h, _ := newTestServer(t)
 	rec := do(h, "/api/config")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp configResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byKey := map[string]configItem{}
+	for _, it := range resp.Items {
+		byKey[it.Key] = it
+	}
+	if byKey["port"].Source != "env" || byKey["port"].Editable {
+		t.Errorf("port should be env/non-editable: %+v", byKey["port"])
+	}
+	if byKey["worker_interval"].Source != "toml" || !byKey["worker_interval"].Editable {
+		t.Errorf("worker_interval should be toml/editable: %+v", byKey["worker_interval"])
+	}
+	if byKey["worker_interval"].Value != "15s" {
+		t.Errorf("worker_interval value = %q, want 15s", byKey["worker_interval"].Value)
+	}
+}
+
+// newConfigServer builds a server whose config file lives in a temp dir, and
+// returns the handler, the config path, and a pointer that records whether a
+// restart was requested.
+func newConfigServer(t *testing.T) (http.Handler, string, *bool) {
+	t.Helper()
+	st, _ := store.Open(filepath.Join(t.TempDir(), "c.db"))
+	t.Cleanup(func() { _ = st.Close() })
+	logs, _ := persistlog.New(t.TempDir())
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+
+	restarted := false
+	h := New(Deps{
+		Store: st, Logs: logs, Metrics: observability.New(),
+		Config: config.Config{
+			Port: "8084", ConfigFile: cfgPath,
+			WorkerInterval: 15 * time.Second, ShutdownTimeout: 10 * time.Second,
+		},
+		RequestRestart: func() { restarted = true },
+	}).Routes(staticStub())
+	return h, cfgPath, &restarted
+}
+
+func putJSON(h http.Handler, target, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestUpdateConfig_WritesTomlFile(t *testing.T) {
+	h, cfgPath, _ := newConfigServer(t)
+	rec := putJSON(h, "/api/config", `{"worker_interval":"20s","shutdown_timeout":"25s"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	fc, err := config.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if fc.WorkerInterval != "20s" || fc.ShutdownTimeout != "25s" {
+		t.Errorf("toml not persisted: %+v", fc)
+	}
+}
+
+func TestUpdateConfig_RejectsInvalidDuration(t *testing.T) {
+	h, _, _ := newConfigServer(t)
+	rec := putJSON(h, "/api/config", `{"worker_interval":"banana"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestRestart_InvokesRequestRestart(t *testing.T) {
+	h, _, restarted := newConfigServer(t)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/restart", nil))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if !*restarted {
+		t.Error("RequestRestart was not invoked")
+	}
+}
+
+func TestRestart_UnsupportedWhenNil(t *testing.T) {
+	h, _ := newTestServer(t) // newTestServer leaves RequestRestart nil
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/restart", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## 概要

Config 画面が env を読み取り専用で表示するだけだったのを、**env（読み取り専用）/ toml（編集可）の二層**に分け、`worker_interval` / `shutdown_timeout` を toml ファイルから読み込んで画面から編集→**再起動で反映**できるようにする。

## 関連 Issue

Closes: #259
Refs: #246

## やったこと

### backend
- `internal/config`: env(`Port`/`DatabaseDSN`/`LogDir`/`ConfigFile`) と toml(`worker_interval`/`shutdown_timeout`) を分離。`ReadFile`/`WriteFile`(atomic rename)/`EnsureFile`(初回生成) を追加。
- `internal/web`: `GET /api/config` を `{configPath, items:[{key,label,value,source,editable}]}` に変更。`PUT /api/config`(toml のみ・env 拒否・duration 検証)、`POST /api/restart` を追加。
- `internal/server`: `ErrRestart` sentinel + restart watcher。restart 要求で worker+web を graceful shutdown。
- `cmd/server`: `run` ループが `ErrRestart` で `Run` を再実行し **in-process で toml を再読込**（プロセス保持）。SIGINT/SIGTERM は従来どおり終了。
- `Makefile`: `go test` を `./cmd/... ./internal/...` に限定し `frontend/node_modules` の Go パッケージ混入を防止（カバレッジ汚染の修正）。

### frontend
- Config 画面を刷新: env はバッジ付き**読み取り専用**、toml は**フォーム編集**。Save→「Restart & apply」(POST /api/restart→`/health` ポーリング→`location.reload()`)。
- `api/config` に `update`/`restart`、`hooks` に `useUpdateConfig`/`useRestart`、schema/types/mock を新形状へ。

## 動作確認

実バイナリで以下を疎通確認:
```
PUT /api/config {worker_interval:"3s"}  → restartRequired:true, config.toml 更新
GET /api/config                          → 実行中は 15s のまま（未反映）
POST /api/restart                        → 202、~0.5s で復帰
GET /api/config                          → 3s（反映）。worker も 3s 間隔に
```
- env(port/database_dsn/log_dir) は read-only、toml(worker_interval/shutdown_timeout) は editable として返ることを確認。
- 再起動を跨いで SQLite データは保持。

## テスト

- [x] `make ci` 相当: go test **80.3%** / golangci-lint **0 issues** / vitest **23** / eslint / tsc / vite build すべて緑

## チェックリスト

- [x] `Closes:` を sub-issue 相当の #259 に使用、親 #246 は `Refs:`
- [x] 機密情報を含まない（config は secrets を持たない）
- [x] PR タイトルが Conventional Commits 形式
- [ ] base ブランチが `main` → **#258（Tailwind 修正）にスタック**。#258 マージ後に main へ retarget され diff が収束する

## 補足 / レビュー観点

- 「再起動」は別バイナリの再 exec ではなく `Run(ctx)` ループによる **in-process リロード**。設定再読込が目的で十分かつテスト可能。プロセス/ポートは保持（Go の `SO_REUSEADDR` で再 listen）。
- `config.toml` は runtime 状態として `.gitignore` 済み（`*.db` 等と同様、初回起動で既定値生成）。