### PR TITLE
feat(go-react-admin): Job 管理画面（cron スケジュール）と job 別実行履歴

### DIFF
--- a/go-react-admin/frontend/src/App.tsx
+++ b/go-react-admin/frontend/src/App.tsx
@@ -4,6 +4,9 @@ import { Layout } from "@/components";
 import {
   RunsPage,
   RunDetailPage,
+  JobsPage,
+  JobDetailPage,
+  JobFormPage,
   MetricsPage,
   LogsPage,
   ConfigPage,
@@ -28,6 +31,10 @@ function App() {
             <Route index element={<Navigate to="/runs" replace />} />
             <Route path="runs" element={<RunsPage />} />
             <Route path="runs/:id" element={<RunDetailPage />} />
+            <Route path="jobs" element={<JobsPage />} />
+            <Route path="jobs/new" element={<JobFormPage />} />
+            <Route path="jobs/:id" element={<JobDetailPage />} />
+            <Route path="jobs/:id/edit" element={<JobFormPage />} />
             <Route path="metrics" element={<MetricsPage />} />
             <Route path="logs" element={<LogsPage />} />
             <Route path="config" element={<ConfigPage />} />

--- a/go-react-admin/frontend/src/api/client.ts
+++ b/go-react-admin/frontend/src/api/client.ts
@@ -16,8 +16,13 @@ export const apiClient = ky.create({
         const { response } = error;
         if (response) {
           try {
-            const body = await response.json();
-            const message = (body as { message?: string }).message || error.message;
+            const body = (await response.json()) as {
+              message?: string;
+              error?: string;
+            };
+            // Most endpoints use { message }; the jobs API uses { error } (e.g.
+            // invalid cron). Fall back to either so the UI can surface the reason.
+            const message = body.message || body.error || error.message;
             logger.error(`API ${response.url} failed: ${response.status}`, message);
             error.message = message;
           } catch {

--- a/go-react-admin/frontend/src/api/jobs.test.ts
+++ b/go-react-admin/frontend/src/api/jobs.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { jobsApi } from "./jobs";
+
+describe("jobsApi", () => {
+  it("lists jobs and validates the response shape", async () => {
+    const res = await jobsApi.list();
+    expect(res.items).toHaveLength(2);
+    expect(res.items[0].name).toBe("nightly-export");
+    expect(res.items[1].enabled).toBe(false);
+  });
+
+  it("fetches a single job", async () => {
+    const job = await jobsApi.get(10);
+    expect(job.id).toBe(10);
+    expect(job.schedule).toBe("0 2 * * *");
+  });
+
+  it("creates a job and echoes it back", async () => {
+    const job = await jobsApi.create({ name: "new-job", schedule: "@hourly" });
+    expect(job.id).toBe(99);
+    expect(job.name).toBe("new-job");
+    expect(job.kind).toBe("task");
+  });
+
+  it("surfaces the server { error } on validation failure", async () => {
+    await expect(jobsApi.create({ name: "", schedule: "bad" })).rejects.toThrow(
+      "name is required"
+    );
+  });
+});

--- a/go-react-admin/frontend/src/api/jobs.ts
+++ b/go-react-admin/frontend/src/api/jobs.ts
@@ -1,0 +1,31 @@
+import { apiClient } from "./client";
+import { jobViewSchema, jobsResponseSchema } from "@/schemas/job";
+import type { JobInput, JobView, JobsResponse } from "@/types/job";
+
+// The client's beforeError hook surfaces the server's { error } text (e.g.
+// invalid cron) as the thrown Error message, so callers can show it directly.
+export const jobsApi = {
+  list: async (): Promise<JobsResponse> => {
+    const json = await apiClient.get("api/jobs").json();
+    return jobsResponseSchema.parse(json);
+  },
+
+  get: async (id: number): Promise<JobView> => {
+    const json = await apiClient.get(`api/jobs/${id}`).json();
+    return jobViewSchema.parse(json);
+  },
+
+  create: async (input: JobInput): Promise<JobView> => {
+    const json = await apiClient.post("api/jobs", { json: input }).json();
+    return jobViewSchema.parse(json);
+  },
+
+  update: async (id: number, input: JobInput): Promise<JobView> => {
+    const json = await apiClient.put(`api/jobs/${id}`, { json: input }).json();
+    return jobViewSchema.parse(json);
+  },
+
+  remove: async (id: number): Promise<void> => {
+    await apiClient.delete(`api/jobs/${id}`);
+  },
+};

--- a/go-react-admin/frontend/src/components/Layout.tsx
+++ b/go-react-admin/frontend/src/components/Layout.tsx
@@ -1,5 +1,12 @@
 import { NavLink, Outlet } from "react-router-dom";
-import { Activity, BarChart3, FileText, ListChecks, Settings } from "lucide-react";
+import {
+  Activity,
+  BarChart3,
+  CalendarClock,
+  FileText,
+  ListChecks,
+  Settings,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -10,6 +17,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { to: "/runs", label: "Runs", icon: ListChecks },
+  { to: "/jobs", label: "Jobs", icon: CalendarClock },
   { to: "/metrics", label: "Metrics", icon: BarChart3 },
   { to: "/logs", label: "Logs", icon: FileText },
   { to: "/config", label: "Config", icon: Settings },

--- a/go-react-admin/frontend/src/hooks/index.ts
+++ b/go-react-admin/frontend/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useRuns, useRun } from "./useRuns";
 export { useMetrics } from "./useMetrics";
 export { useConfig } from "./useConfig";
+export { useJobs, useJob, useCreateJob, useUpdateJob, useDeleteJob } from "./useJobs";

--- a/go-react-admin/frontend/src/hooks/useJobs.ts
+++ b/go-react-admin/frontend/src/hooks/useJobs.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { jobsApi } from "@/api/jobs";
+import type { JobInput } from "@/types/job";
+
+export function useJobs() {
+  return useQuery({
+    queryKey: ["jobs"],
+    queryFn: () => jobsApi.list(),
+  });
+}
+
+export function useJob(id: number | undefined) {
+  return useQuery({
+    queryKey: ["job", id],
+    queryFn: () => jobsApi.get(id as number),
+    enabled: id != null && !Number.isNaN(id),
+  });
+}
+
+export function useCreateJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: JobInput) => jobsApi.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+}
+
+export function useUpdateJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: number; input: JobInput }) =>
+      jobsApi.update(id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+}
+
+export function useDeleteJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => jobsApi.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+}

--- a/go-react-admin/frontend/src/pages/JobDetailPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/JobDetailPage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { JobDetailPage } from "./JobDetailPage";
+
+function renderDetail(id: number) {
+  return render(
+    <Routes>
+      <Route path="/jobs/:id" element={<JobDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/jobs/${id}`] }
+  );
+}
+
+describe("JobDetailPage", () => {
+  it("shows job info and its run history", async () => {
+    renderDetail(10);
+
+    await waitFor(() => {
+      expect(screen.getByText("nightly-export")).toBeInTheDocument();
+    });
+    expect(screen.getByText("0 2 * * *")).toBeInTheDocument();
+    expect(screen.getByText("enabled")).toBeInTheDocument();
+    expect(screen.getByText("Run history")).toBeInTheDocument();
+
+    // Run #1 belongs to job 10 (jobId 10).
+    await waitFor(() => {
+      expect(screen.getByText("succeeded")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error for an unknown job id", async () => {
+    renderDetail(404);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load job/)).toBeInTheDocument();
+    });
+  });
+});

--- a/go-react-admin/frontend/src/pages/JobDetailPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobDetailPage.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { DataTable } from "@/components/admin/data-table";
+import { Pagination } from "@/components/admin/pagination";
+import { StatusBadge } from "@/components/admin/status-badge";
+import { Button } from "@/components/ui/button";
+import { useJob, useDeleteJob } from "@/hooks/useJobs";
+import { useRuns } from "@/hooks/useRuns";
+import { statusTone, formatDuration } from "@/lib/status";
+import type { JobView } from "@/types/job";
+import type { Run } from "@/types/run";
+
+const PAGE_SIZE = 20;
+
+export function JobDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id ? Number(params.id) : undefined;
+  const { data, isLoading, isError, error } = useJob(id);
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500">Loading…</div>;
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex flex-col gap-4">
+        <BackLink />
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          Failed to load job: {(error as Error)?.message ?? "not found"}
+        </div>
+      </div>
+    );
+  }
+
+  return <JobDetail job={data} />;
+}
+
+function JobDetail({ job }: { job: JobView }) {
+  const navigate = useNavigate();
+  const deleteJob = useDeleteJob();
+  const [page, setPage] = useState(1);
+
+  const { data: runs, isLoading: runsLoading } = useRuns({
+    jobId: job.id,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const onDelete = () => {
+    if (!window.confirm(`Delete job "${job.name}"?`)) return;
+    deleteJob.mutate(job.id, { onSuccess: () => navigate("/jobs") });
+  };
+
+  const columns = [
+    { header: "ID", cell: (row: Run) => row.id, align: "right" as const },
+    {
+      header: "Status",
+      cell: (row: Run) => (
+        <StatusBadge tone={statusTone(row.status)} label={row.status} />
+      ),
+    },
+    { header: "Started", cell: (row: Run) => row.startedAt },
+    {
+      header: "Duration",
+      cell: (row: Run) => formatDuration(row.startedAt, row.finishedAt),
+      align: "right" as const,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-xl font-semibold">{job.name}</h1>
+          <StatusBadge
+            tone={job.enabled ? "success" : "neutral"}
+            label={job.enabled ? "enabled" : "disabled"}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/jobs/${job.id}/edit`}>Edit</Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDelete}
+            disabled={deleteJob.isPending}
+          >
+            Delete
+          </Button>
+        </div>
+      </header>
+
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+        <Field label="Kind" value={job.kind} />
+        <Field label="Schedule" value={job.schedule} mono />
+        <Field label="Runs" value={String(job.runCount)} />
+        <Field label="Last run" value={job.lastRunAt ?? "—"} />
+        <Field label="Next run" value={job.nextRunAt ?? "—"} />
+        <Field label="Created" value={job.createdAt} />
+      </dl>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold text-slate-700">Run history</h2>
+        <DataTable<Run>
+          columns={columns}
+          rows={runs?.items ?? []}
+          getRowKey={(row) => row.id}
+          onRowClick={(row) => navigate(`/runs/${row.id}`)}
+          emptyMessage={runsLoading ? "Loading…" : "No runs yet"}
+        />
+        <Pagination
+          page={runs?.page ?? page}
+          pageSize={runs?.pageSize ?? PAGE_SIZE}
+          total={runs?.total ?? 0}
+          onPageChange={setPage}
+        />
+      </section>
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-slate-500">{label}</dt>
+      <dd className={mono ? "font-mono text-xs text-slate-700" : "text-slate-700"}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      to="/jobs"
+      className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to jobs
+    </Link>
+  );
+}

--- a/go-react-admin/frontend/src/pages/JobFormPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/JobFormPage.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { JobFormPage } from "./JobFormPage";
+
+function renderForm(entry: string) {
+  return render(
+    <Routes>
+      <Route path="/jobs/new" element={<JobFormPage />} />
+      <Route path="/jobs" element={<div>jobs list</div>} />
+    </Routes>,
+    { initialEntries: [entry] }
+  );
+}
+
+describe("JobFormPage (create)", () => {
+  it("submits a new job and navigates to the jobs list", async () => {
+    const user = userEvent.setup();
+    renderForm("/jobs/new");
+
+    expect(screen.getByText("New job")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox", { name: "Name" }), "new-job");
+    await user.type(screen.getByRole("textbox", { name: "Schedule" }), "@hourly");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("jobs list")).toBeInTheDocument();
+    });
+  });
+});

--- a/go-react-admin/frontend/src/pages/JobFormPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobFormPage.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { useJob, useCreateJob, useUpdateJob } from "@/hooks/useJobs";
+import type { JobInput, JobView } from "@/types/job";
+
+// JobFormPage is the route entry. For /jobs/new it renders the form immediately;
+// for /jobs/:id/edit it waits for the job to load, then mounts JobForm with the
+// loaded values as initial state (no effect-based seeding).
+export function JobFormPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id ? Number(params.id) : undefined;
+
+  if (id == null) {
+    return <JobForm mode="create" />;
+  }
+  return <EditJobForm id={id} />;
+}
+
+function EditJobForm({ id }: { id: number }) {
+  const { data, isLoading, isError, error } = useJob(id);
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500">Loading…</div>;
+  }
+  if (isError || !data) {
+    return (
+      <div className="flex flex-col gap-4">
+        <CancelLink />
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          Failed to load job: {(error as Error)?.message ?? "not found"}
+        </div>
+      </div>
+    );
+  }
+  return <JobForm mode="edit" id={id} job={data} />;
+}
+
+interface JobFormProps {
+  mode: "create" | "edit";
+  id?: number;
+  job?: JobView;
+}
+
+function JobForm({ mode, id, job }: JobFormProps) {
+  const navigate = useNavigate();
+  const createJob = useCreateJob();
+  const updateJob = useUpdateJob();
+
+  const [name, setName] = useState(job?.name ?? "");
+  const [kind, setKind] = useState(job?.kind ?? "");
+  const [schedule, setSchedule] = useState(job?.schedule ?? "");
+  const [enabled, setEnabled] = useState(job?.enabled ?? true);
+
+  const mutation = mode === "edit" ? updateJob : createJob;
+  const serverError = mutation.isError ? (mutation.error as Error)?.message : undefined;
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const input: JobInput = {
+      name,
+      kind: kind || undefined,
+      schedule,
+      enabled,
+    };
+    if (mode === "edit" && id != null) {
+      updateJob.mutate({ id, input }, { onSuccess: () => navigate("/jobs") });
+    } else {
+      createJob.mutate(input, { onSuccess: () => navigate("/jobs") });
+    }
+  };
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-6">
+      <h1 className="text-xl font-semibold">
+        {mode === "edit" ? "Edit job" : "New job"}
+      </h1>
+
+      {serverError && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {serverError}
+        </div>
+      )}
+
+      <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-slate-700">Name</span>
+          <input
+            aria-label="Name"
+            className="rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-400 focus:outline-none"
+            value={name}
+            required
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-slate-700">Kind</span>
+          <input
+            aria-label="Kind"
+            className="rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-400 focus:outline-none"
+            value={kind}
+            placeholder="task"
+            onChange={(e) => setKind(e.target.value)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-slate-700">Schedule</span>
+          <input
+            aria-label="Schedule"
+            className="rounded-md border border-slate-300 px-2 py-1 font-mono text-sm focus:border-indigo-400 focus:outline-none"
+            value={schedule}
+            required
+            onChange={(e) => setSchedule(e.target.value)}
+          />
+          <span className="text-xs text-slate-400">
+            Cron spec, e.g. <span className="font-mono">@every 20s</span>,{" "}
+            <span className="font-mono">0 2 * * *</span>,{" "}
+            <span className="font-mono">@hourly</span>.
+          </span>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          <span className="text-sm font-medium text-slate-700">Enabled</span>
+        </label>
+
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? "Saving…" : "Save"}
+          </Button>
+          <Link to="/jobs" className="text-sm text-slate-500 hover:text-slate-800">
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function CancelLink() {
+  return (
+    <Link to="/jobs" className="text-sm text-slate-500 hover:text-slate-800">
+      Cancel
+    </Link>
+  );
+}

--- a/go-react-admin/frontend/src/pages/JobsPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/JobsPage.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { JobsPage } from "./JobsPage";
+
+describe("JobsPage", () => {
+  it("renders jobs from the API", async () => {
+    render(<JobsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("nightly-export")).toBeInTheDocument();
+    });
+    expect(screen.getByText("sync-users")).toBeInTheDocument();
+    expect(screen.getByText("enabled")).toBeInTheDocument();
+    expect(screen.getByText("disabled")).toBeInTheDocument();
+    expect(screen.getByText("0 2 * * *")).toBeInTheDocument();
+  });
+
+  it("has a New job link", async () => {
+    render(<JobsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("nightly-export")).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: /New job/ });
+    expect(link).toHaveAttribute("href", "/jobs/new");
+  });
+});

--- a/go-react-admin/frontend/src/pages/JobsPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobsPage.tsx
@@ -1,0 +1,97 @@
+import { Link, useNavigate } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { DataTable } from "@/components/admin/data-table";
+import { StatusBadge } from "@/components/admin/status-badge";
+import { KindBadge } from "@/components/admin/kind-badge";
+import { Button } from "@/components/ui/button";
+import { useJobs, useDeleteJob } from "@/hooks/useJobs";
+import type { JobView } from "@/types/job";
+
+export function JobsPage() {
+  const navigate = useNavigate();
+  const { data, isLoading, isError, error } = useJobs();
+  const deleteJob = useDeleteJob();
+
+  const onDelete = (job: JobView) => {
+    if (!window.confirm(`Delete job "${job.name}"?`)) return;
+    deleteJob.mutate(job.id);
+  };
+
+  const columns = [
+    { header: "Name", cell: (row: JobView) => row.name },
+    {
+      header: "Kind",
+      cell: (row: JobView) => <KindBadge label={row.kind} />,
+    },
+    {
+      header: "Schedule",
+      cell: (row: JobView) => <span className="font-mono text-xs">{row.schedule}</span>,
+    },
+    {
+      header: "Enabled",
+      cell: (row: JobView) => (
+        <StatusBadge
+          tone={row.enabled ? "success" : "neutral"}
+          label={row.enabled ? "enabled" : "disabled"}
+        />
+      ),
+    },
+    { header: "Last run", cell: (row: JobView) => row.lastRunAt ?? "—" },
+    { header: "Next run", cell: (row: JobView) => row.nextRunAt ?? "—" },
+    {
+      header: "Runs",
+      cell: (row: JobView) => row.runCount,
+      align: "right" as const,
+    },
+    {
+      header: "",
+      cell: (row: JobView) => (
+        <div
+          className="flex items-center justify-end gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button asChild variant="outline" size="sm">
+            <Link to={`/jobs/${row.id}/edit`}>Edit</Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onDelete(row)}
+            disabled={deleteJob.isPending}
+          >
+            Delete
+          </Button>
+        </div>
+      ),
+      align: "right" as const,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Jobs</h1>
+        <Button asChild>
+          <Link to="/jobs/new">
+            <Plus className="h-4 w-4" />
+            New job
+          </Link>
+        </Button>
+      </header>
+
+      {isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          Failed to load jobs: {(error as Error)?.message}
+        </div>
+      ) : (
+        <DataTable<JobView>
+          columns={columns}
+          rows={data?.items ?? []}
+          getRowKey={(row) => row.id}
+          onRowClick={(row) => navigate(`/jobs/${row.id}`)}
+          emptyMessage={isLoading ? "Loading…" : "No jobs"}
+        />
+      )}
+    </div>
+  );
+}

--- a/go-react-admin/frontend/src/pages/index.ts
+++ b/go-react-admin/frontend/src/pages/index.ts
@@ -1,5 +1,8 @@
 export { RunsPage } from "./RunsPage";
 export { RunDetailPage } from "./RunDetailPage";
+export { JobsPage } from "./JobsPage";
+export { JobDetailPage } from "./JobDetailPage";
+export { JobFormPage } from "./JobFormPage";
 export { MetricsPage } from "./MetricsPage";
 export { LogsPage } from "./LogsPage";
 export { ConfigPage } from "./ConfigPage";

--- a/go-react-admin/frontend/src/schemas/job.ts
+++ b/go-react-admin/frontend/src/schemas/job.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const jobViewSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  kind: z.string(),
+  schedule: z.string(),
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  lastRunAt: z.string().nullable(),
+  nextRunAt: z.string().nullable(),
+  runCount: z.number(),
+});
+
+export const jobsResponseSchema = z.object({
+  items: z.array(jobViewSchema),
+});

--- a/go-react-admin/frontend/src/test/mocks/handlers.ts
+++ b/go-react-admin/frontend/src/test/mocks/handlers.ts
@@ -5,6 +5,7 @@ import type {
   MetricsAggregateResponse,
   ConfigResponse,
 } from "@/types/run";
+import type { JobView } from "@/types/job";
 
 // Relative "*/api/..." patterns match regardless of the resolved origin, so the
 // same handlers work whether VITE_API_BASE_URL is empty (same-origin) or set.
@@ -36,6 +37,31 @@ export const mockRuns: Run[] = [
     startedAt: "2026-06-16T03:00:00Z",
     finishedAt: "2026-06-16T03:00:45Z",
     createdAt: "2026-06-16T02:59:00Z",
+  },
+];
+
+export const mockJobs: JobView[] = [
+  {
+    id: 10,
+    name: "nightly-export",
+    kind: "task",
+    schedule: "0 2 * * *",
+    enabled: true,
+    createdAt: "2026-06-01T00:00:00Z",
+    lastRunAt: "2026-06-16T01:00:00Z",
+    nextRunAt: "2026-06-17T02:00:00Z",
+    runCount: 12,
+  },
+  {
+    id: 11,
+    name: "sync-users",
+    kind: "task",
+    schedule: "@every 20s",
+    enabled: false,
+    createdAt: "2026-06-02T00:00:00Z",
+    lastRunAt: null,
+    nextRunAt: null,
+    runCount: 0,
   },
 ];
 
@@ -154,7 +180,10 @@ export const handlers = [
   http.get("*/api/runs", ({ request }) => {
     const url = new URL(request.url);
     const status = url.searchParams.get("status");
-    const items = status ? mockRuns.filter((r) => r.status === status) : mockRuns;
+    const jobId = url.searchParams.get("job_id");
+    let items = mockRuns;
+    if (status) items = items.filter((r) => r.status === status);
+    if (jobId) items = items.filter((r) => r.jobId === Number(jobId));
     return HttpResponse.json({
       items,
       total: items.length,
@@ -170,6 +199,68 @@ export const handlers = [
       return HttpResponse.json({ message: "run not found" }, { status: 404 });
     }
     return HttpResponse.json({ ...mockRunDetail, run });
+  }),
+
+  http.get("*/api/jobs", () => {
+    return HttpResponse.json({ items: mockJobs });
+  }),
+
+  http.post("*/api/jobs", async ({ request }) => {
+    const body = (await request.json()) as {
+      name?: string;
+      kind?: string;
+      schedule?: string;
+      enabled?: boolean;
+    };
+    if (!body.name) {
+      return HttpResponse.json({ error: "name is required" }, { status: 400 });
+    }
+    const job: JobView = {
+      id: 99,
+      name: body.name,
+      kind: body.kind ?? "task",
+      schedule: body.schedule ?? "",
+      enabled: body.enabled ?? true,
+      createdAt: "2026-06-17T00:00:00Z",
+      lastRunAt: null,
+      nextRunAt: null,
+      runCount: 0,
+    };
+    return HttpResponse.json(job, { status: 201 });
+  }),
+
+  http.get("*/api/jobs/:id", ({ params }) => {
+    const id = Number(params.id);
+    const job = mockJobs.find((j) => j.id === id);
+    if (!job) {
+      return HttpResponse.json({ error: "job not found" }, { status: 404 });
+    }
+    return HttpResponse.json(job);
+  }),
+
+  http.put("*/api/jobs/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const job = mockJobs.find((j) => j.id === id);
+    if (!job) {
+      return HttpResponse.json({ error: "job not found" }, { status: 404 });
+    }
+    const body = (await request.json()) as {
+      name?: string;
+      kind?: string;
+      schedule?: string;
+      enabled?: boolean;
+    };
+    return HttpResponse.json({
+      ...job,
+      name: body.name ?? job.name,
+      kind: body.kind ?? job.kind,
+      schedule: body.schedule ?? job.schedule,
+      enabled: body.enabled ?? job.enabled,
+    });
+  }),
+
+  http.delete("*/api/jobs/:id", () => {
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.get("*/api/metrics/aggregate", () => {

--- a/go-react-admin/frontend/src/types/job.ts
+++ b/go-react-admin/frontend/src/types/job.ts
@@ -1,0 +1,12 @@
+import type { z } from "zod";
+import type { jobViewSchema, jobsResponseSchema } from "@/schemas/job";
+
+export type JobView = z.infer<typeof jobViewSchema>;
+export type JobsResponse = z.infer<typeof jobsResponseSchema>;
+
+export interface JobInput {
+  name: string;
+  kind?: string;
+  schedule: string;
+  enabled?: boolean;
+}

--- a/go-react-admin/go.mod
+++ b/go-react-admin/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/lmittmann/tint v1.1.3
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.19.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sethvargo/go-envconfig v1.3.0
 	golang.org/x/sync v0.20.0
 	modernc.org/sqlite v1.52.0

--- a/go-react-admin/go.sum
+++ b/go-react-admin/go.sum
@@ -75,6 +75,8 @@ github.com/quic-go/quic-go v0.54.0 h1:6s1YB9QotYI6Ospeiguknbp2Znb/jZYjZLRXn9kMQB
 github.com/quic-go/quic-go v0.54.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/sethvargo/go-envconfig v1.3.0 h1:gJs+Fuv8+f05omTpwWIu6KmuseFAXKrIaOZSh8RMt0U=
 github.com/sethvargo/go-envconfig v1.3.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go-react-admin/internal/schedule/schedule.go
+++ b/go-react-admin/internal/schedule/schedule.go
@@ -1,0 +1,45 @@
+// Package schedule wraps cron parsing so the worker (scheduling) and the web
+// layer (validation) share one spec dialect.
+//
+// The parser accepts standard 5-field cron ("0 2 * * *"), an optional leading
+// seconds field ("*/10 * * * * *"), and descriptors ("@every 20s", "@hourly").
+package schedule
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+var parser = cron.NewParser(
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+)
+
+// Schedule computes the next activation after a given time.
+type Schedule = cron.Schedule
+
+// Parse compiles a cron spec.
+func Parse(spec string) (Schedule, error) {
+	s, err := parser.Parse(spec)
+	if err != nil {
+		return nil, fmt.Errorf("invalid schedule %q: %w", spec, err)
+	}
+	return s, nil
+}
+
+// Valid reports whether spec is a parseable schedule.
+func Valid(spec string) error {
+	_, err := Parse(spec)
+	return err
+}
+
+// Next returns the next activation strictly after `after`, or the zero time if
+// the spec is invalid.
+func Next(spec string, after time.Time) time.Time {
+	s, err := Parse(spec)
+	if err != nil {
+		return time.Time{}
+	}
+	return s.Next(after)
+}

--- a/go-react-admin/internal/schedule/schedule_test.go
+++ b/go-react-admin/internal/schedule/schedule_test.go
@@ -1,0 +1,41 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse_AcceptsCronDescriptorAndSeconds(t *testing.T) {
+	for _, spec := range []string{"0 2 * * *", "@every 20s", "@hourly", "*/10 * * * * *"} {
+		if _, err := Parse(spec); err != nil {
+			t.Errorf("Parse(%q) error = %v, want nil", spec, err)
+		}
+	}
+}
+
+func TestParse_RejectsGarbage(t *testing.T) {
+	if _, err := Parse("not a cron"); err == nil {
+		t.Error("Parse(garbage) = nil error, want error")
+	}
+}
+
+func TestValid(t *testing.T) {
+	if err := Valid("@every 1m"); err != nil {
+		t.Errorf("Valid(@every 1m) = %v", err)
+	}
+	if err := Valid("?!"); err == nil {
+		t.Error("Valid(?!) = nil, want error")
+	}
+}
+
+func TestNext(t *testing.T) {
+	base := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	next := Next("@every 1h", base)
+	if !next.Equal(base.Add(time.Hour)) {
+		t.Errorf("Next = %v, want %v", next, base.Add(time.Hour))
+	}
+	// Invalid spec yields the zero time.
+	if !Next("garbage", base).IsZero() {
+		t.Error("Next(garbage) should be zero time")
+	}
+}

--- a/go-react-admin/internal/store/queries.go
+++ b/go-react-admin/internal/store/queries.go
@@ -8,22 +8,40 @@ import (
 )
 
 // CreateJob inserts a job and returns it with its assigned ID.
-func (s *Store) CreateJob(name, kind string, enabled bool) (Job, error) {
+func (s *Store) CreateJob(name, kind, schedule string, enabled bool) (Job, error) {
 	now := time.Now().UTC()
 	res, err := s.db.Exec(
-		`INSERT INTO jobs (name, kind, enabled, created_at) VALUES (?, ?, ?, ?)`,
-		name, kind, boolToInt(enabled), fmtTime(now),
+		`INSERT INTO jobs (name, kind, schedule, enabled, created_at) VALUES (?, ?, ?, ?, ?)`,
+		name, kind, schedule, boolToInt(enabled), fmtTime(now),
 	)
 	if err != nil {
 		return Job{}, fmt.Errorf("insert job: %w", err)
 	}
 	id, _ := res.LastInsertId()
-	return Job{ID: id, Name: name, Kind: kind, Enabled: enabled, CreatedAt: now}, nil
+	return Job{ID: id, Name: name, Kind: kind, Schedule: schedule, Enabled: enabled, CreatedAt: now}, nil
+}
+
+const jobColumns = `id, name, kind, schedule, enabled, created_at`
+
+func scanJob(sc rowScanner) (Job, error) {
+	var j Job
+	var enabled int
+	var created string
+	if err := sc.Scan(&j.ID, &j.Name, &j.Kind, &j.Schedule, &enabled, &created); err != nil {
+		return Job{}, err
+	}
+	j.Enabled = enabled != 0
+	t, err := parseTime(created)
+	if err != nil {
+		return Job{}, err
+	}
+	j.CreatedAt = t
+	return j, nil
 }
 
 // ListJobs returns all jobs ordered by id.
 func (s *Store) ListJobs() ([]Job, error) {
-	rows, err := s.db.Query(`SELECT id, name, kind, enabled, created_at FROM jobs ORDER BY id`)
+	rows, err := s.db.Query(`SELECT ` + jobColumns + ` FROM jobs ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("query jobs: %w", err)
 	}
@@ -31,19 +49,87 @@ func (s *Store) ListJobs() ([]Job, error) {
 
 	var jobs []Job
 	for rows.Next() {
-		var j Job
-		var enabled int
-		var created string
-		if err = rows.Scan(&j.ID, &j.Name, &j.Kind, &enabled, &created); err != nil {
-			return nil, err
-		}
-		j.Enabled = enabled != 0
-		if j.CreatedAt, err = parseTime(created); err != nil {
+		j, err := scanJob(rows)
+		if err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, j)
 	}
 	return jobs, rows.Err()
+}
+
+// GetJob returns one job by id, or ErrNotFound.
+func (s *Store) GetJob(id int64) (Job, error) {
+	j, err := scanJob(s.db.QueryRow(`SELECT `+jobColumns+` FROM jobs WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return Job{}, ErrNotFound
+	}
+	return j, err
+}
+
+// UpdateJob updates a job's mutable fields. Returns ErrNotFound if absent.
+func (s *Store) UpdateJob(id int64, name, kind, schedule string, enabled bool) (Job, error) {
+	res, err := s.db.Exec(
+		`UPDATE jobs SET name = ?, kind = ?, schedule = ?, enabled = ? WHERE id = ?`,
+		name, kind, schedule, boolToInt(enabled), id,
+	)
+	if err != nil {
+		return Job{}, fmt.Errorf("update job: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return Job{}, ErrNotFound
+	}
+	return s.GetJob(id)
+}
+
+// DeleteJob removes a job and all of its runs/phases/metrics in one
+// transaction. Returns ErrNotFound if the job does not exist.
+func (s *Store) DeleteJob(id int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err = tx.Exec(
+		`DELETE FROM phases WHERE run_id IN (SELECT id FROM runs WHERE job_id = ?)`, id); err != nil {
+		return fmt.Errorf("delete phases: %w", err)
+	}
+	if _, err = tx.Exec(
+		`DELETE FROM metrics WHERE run_id IN (SELECT id FROM runs WHERE job_id = ?)`, id); err != nil {
+		return fmt.Errorf("delete metrics: %w", err)
+	}
+	if _, err = tx.Exec(`DELETE FROM runs WHERE job_id = ?`, id); err != nil {
+		return fmt.Errorf("delete runs: %w", err)
+	}
+	res, err := tx.Exec(`DELETE FROM jobs WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete job: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return tx.Commit()
+}
+
+// LastRunStart returns the most recent run start time for a job, or nil if the
+// job has never run.
+func (s *Store) LastRunStart(jobID int64) (*time.Time, error) {
+	var started sql.NullString
+	err := s.db.QueryRow(`SELECT MAX(started_at) FROM runs WHERE job_id = ?`, jobID).Scan(&started)
+	if err != nil {
+		return nil, fmt.Errorf("last run start: %w", err)
+	}
+	return parseNullTime(started)
+}
+
+// CountRunsByJob returns how many runs a job has produced.
+func (s *Store) CountRunsByJob(jobID int64) (int, error) {
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM runs WHERE job_id = ?`, jobID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count runs by job: %w", err)
+	}
+	return n, nil
 }
 
 // CreateRun inserts a run in the running state and returns it.

--- a/go-react-admin/internal/store/store.go
+++ b/go-react-admin/internal/store/store.go
@@ -25,11 +25,12 @@ const (
 	StatusFailed    RunStatus = "failed"
 )
 
-// Job is a unit of work the worker executes periodically.
+// Job is a unit of work the worker runs on a cron schedule.
 type Job struct {
 	CreatedAt time.Time `json:"createdAt"`
 	Name      string    `json:"name"`
 	Kind      string    `json:"kind"`
+	Schedule  string    `json:"schedule"` // cron spec (see internal/schedule)
 	ID        int64     `json:"id"`
 	Enabled   bool      `json:"enabled"`
 }
@@ -75,6 +76,7 @@ CREATE TABLE IF NOT EXISTS jobs (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
   name       TEXT NOT NULL,
   kind       TEXT NOT NULL,
+  schedule   TEXT NOT NULL DEFAULT '',
   enabled    INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL
 );
@@ -128,6 +130,42 @@ func Open(dsn string) (*Store, error) {
 func (s *Store) migrate() error {
 	if _, err := s.db.Exec(schema); err != nil {
 		return fmt.Errorf("apply schema: %w", err)
+	}
+	// Additive migration for databases created before `schedule` existed.
+	if err := s.addColumnIfMissing("jobs", "schedule", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// addColumnIfMissing performs an idempotent ALTER TABLE ADD COLUMN, so upgrading
+// an existing database picks up new columns without a migration tool.
+func (s *Store) addColumnIfMissing(table, column, ddl string) error {
+	rows, err := s.db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			cid        int
+			name, ctyp string
+			notnull    int
+			dflt       sql.NullString
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &ctyp, &notnull, &dflt, &pk); err != nil {
+			return err
+		}
+		if name == column {
+			return rows.Close()
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if _, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, ddl)); err != nil {
+		return fmt.Errorf("add column %s.%s: %w", table, column, err)
 	}
 	return nil
 }

--- a/go-react-admin/internal/store/store_test.go
+++ b/go-react-admin/internal/store/store_test.go
@@ -19,7 +19,7 @@ func newTestStore(t *testing.T) *Store {
 func TestJobsAndRunsLifecycle(t *testing.T) {
 	s := newTestStore(t)
 
-	job, err := s.CreateJob("nightly", "batch", true)
+	job, err := s.CreateJob("nightly", "batch", "@every 1m", true)
 	if err != nil {
 		t.Fatalf("CreateJob: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestGetRun_NotFound(t *testing.T) {
 
 func TestListRuns_FilterAndPaging(t *testing.T) {
 	s := newTestStore(t)
-	job, _ := s.CreateJob("j", "k", true)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
 	base := time.Now().UTC()
 	for i := 0; i < 5; i++ {
 		r, _ := s.CreateRun(job.ID, base.Add(time.Duration(i)*time.Second))
@@ -137,7 +137,7 @@ func TestListRuns_FilterAndPaging(t *testing.T) {
 
 func TestListRuns_DefaultPaging(t *testing.T) {
 	s := newTestStore(t)
-	job, _ := s.CreateJob("j", "k", true)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
 	for i := 0; i < 3; i++ {
 		_, _ = s.CreateRun(job.ID, time.Now().UTC())
 	}
@@ -153,7 +153,7 @@ func TestListRuns_DefaultPaging(t *testing.T) {
 
 func TestAggregateMetrics_EmptyAndRawBuckets(t *testing.T) {
 	s := newTestStore(t)
-	job, _ := s.CreateJob("j", "k", true)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
 	run, _ := s.CreateRun(job.ID, time.Now().UTC())
 
 	// No metrics in range → empty series.
@@ -180,7 +180,7 @@ func TestAggregateMetrics_EmptyAndRawBuckets(t *testing.T) {
 
 func TestAggregateMetrics(t *testing.T) {
 	s := newTestStore(t)
-	job, _ := s.CreateJob("j", "k", true)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
 	run, _ := s.CreateRun(job.ID, time.Now().UTC())
 
 	t0 := time.Date(2026, 6, 16, 10, 5, 0, 0, time.UTC)
@@ -208,4 +208,106 @@ func TestAggregateMetrics(t *testing.T) {
 	if tokens[0].Value != 150 {
 		t.Errorf("first tokens bucket = %v, want 150 (100+50 summed)", tokens[0].Value)
 	}
+}
+
+func TestJobCRUD(t *testing.T) {
+	s := newTestStore(t)
+
+	job, err := s.CreateJob("export", "batch", "@every 1m", true)
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if job.Schedule != "@every 1m" {
+		t.Errorf("schedule = %q", job.Schedule)
+	}
+
+	got, err := s.GetJob(job.ID)
+	if err != nil || got.Name != "export" {
+		t.Fatalf("GetJob = %+v, %v", got, err)
+	}
+
+	upd, err := s.UpdateJob(job.ID, "export2", "cron", "0 3 * * *", false)
+	if err != nil {
+		t.Fatalf("UpdateJob: %v", err)
+	}
+	if upd.Name != "export2" || upd.Schedule != "0 3 * * *" || upd.Enabled {
+		t.Errorf("UpdateJob result = %+v", upd)
+	}
+
+	if _, err := s.GetJob(9999); err != ErrNotFound {
+		t.Errorf("GetJob(missing) = %v, want ErrNotFound", err)
+	}
+	if _, err := s.UpdateJob(9999, "x", "y", "@every 1m", true); err != ErrNotFound {
+		t.Errorf("UpdateJob(missing) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteJob_CascadesRunsPhasesMetrics(t *testing.T) {
+	s := newTestStore(t)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
+	start := time.Now().UTC()
+	run, _ := s.CreateRun(job.ID, start)
+	pid, _ := s.AddPhase(run.ID, 0, "p", start)
+	_ = s.FinishPhase(pid, StatusSucceeded, start)
+	_ = s.AddMetric(run.ID, "tokens", 1, start)
+	_ = s.FinishRun(run.ID, StatusSucceeded, start)
+
+	if err := s.DeleteJob(job.ID); err != nil {
+		t.Fatalf("DeleteJob: %v", err)
+	}
+
+	if _, err := s.GetJob(job.ID); err != ErrNotFound {
+		t.Error("job should be gone")
+	}
+	if runs, _, _ := s.ListRuns(RunFilter{JobID: job.ID}, 1, 10); len(runs) != 0 {
+		t.Error("runs should be cascade-deleted")
+	}
+	if ph, _ := s.ListPhases(run.ID); len(ph) != 0 {
+		t.Error("phases should be cascade-deleted")
+	}
+
+	if err := s.DeleteJob(9999); err != ErrNotFound {
+		t.Errorf("DeleteJob(missing) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLastRunStartAndCount(t *testing.T) {
+	s := newTestStore(t)
+	job, _ := s.CreateJob("j", "k", "@every 1m", true)
+
+	last, err := s.LastRunStart(job.ID)
+	if err != nil {
+		t.Fatalf("LastRunStart: %v", err)
+	}
+	if last != nil {
+		t.Error("never-run job should have nil last run")
+	}
+
+	t0 := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	_, _ = s.CreateRun(job.ID, t0)
+	_, _ = s.CreateRun(job.ID, t0.Add(time.Hour))
+
+	last, _ = s.LastRunStart(job.ID)
+	if last == nil || !last.Equal(t0.Add(time.Hour)) {
+		t.Errorf("LastRunStart = %v, want %v", last, t0.Add(time.Hour))
+	}
+	n, _ := s.CountRunsByJob(job.ID)
+	if n != 2 {
+		t.Errorf("CountRunsByJob = %d, want 2", n)
+	}
+}
+
+func TestMigrate_IdempotentScheduleColumn(t *testing.T) {
+	// Opening the same database twice must not fail re-adding the column.
+	path := filepath.Join(t.TempDir(), "m.db")
+	s1, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open 1: %v", err)
+	}
+	_ = s1.Close()
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open 2 (re-migrate): %v", err)
+	}
+	_ = s2.Close()
 }

--- a/go-react-admin/internal/web/web.go
+++ b/go-react-admin/internal/web/web.go
@@ -9,6 +9,7 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -16,6 +17,7 @@ import (
 	"go-react-admin/internal/config"
 	"go-react-admin/internal/observability"
 	"go-react-admin/internal/persistlog"
+	"go-react-admin/internal/schedule"
 	"go-react-admin/internal/store"
 )
 
@@ -49,6 +51,11 @@ func (s *Server) Routes(staticHandler http.Handler) http.Handler {
 
 	api := r.Group("/api")
 	{
+		api.GET("/jobs", s.listJobs)
+		api.POST("/jobs", s.createJob)
+		api.GET("/jobs/:id", s.getJob)
+		api.PUT("/jobs/:id", s.updateJob)
+		api.DELETE("/jobs/:id", s.deleteJob)
 		api.GET("/runs", s.listRuns)
 		api.GET("/runs/:id", s.getRun)
 		api.GET("/metrics/aggregate", s.metricsAggregate)
@@ -63,6 +70,187 @@ func (s *Server) Routes(staticHandler http.Handler) http.Handler {
 
 func (s *Server) health(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// jobView augments a stored job with scheduling/run info for the Jobs screen.
+type jobView struct {
+	LastRunAt *time.Time `json:"lastRunAt"`
+	NextRunAt *time.Time `json:"nextRunAt"`
+	store.Job
+	RunCount int `json:"runCount"`
+}
+
+func (s *Server) toJobView(job store.Job) (jobView, error) {
+	last, err := s.deps.Store.LastRunStart(job.ID)
+	if err != nil {
+		return jobView{}, err
+	}
+	count, err := s.deps.Store.CountRunsByJob(job.ID)
+	if err != nil {
+		return jobView{}, err
+	}
+	view := jobView{Job: job, LastRunAt: last, RunCount: count}
+	if sched, perr := schedule.Parse(job.Schedule); perr == nil {
+		base := job.CreatedAt
+		if last != nil {
+			base = *last
+		}
+		next := sched.Next(base)
+		view.NextRunAt = &next
+	}
+	return view, nil
+}
+
+func (s *Server) listJobs(c *gin.Context) {
+	jobs, err := s.deps.Store.ListJobs()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	views := make([]jobView, 0, len(jobs))
+	for _, job := range jobs {
+		v, err := s.toJobView(job)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		views = append(views, v)
+	}
+	c.JSON(http.StatusOK, gin.H{"items": views})
+}
+
+type jobRequest struct {
+	Enabled  *bool  `json:"enabled"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Schedule string `json:"schedule"`
+}
+
+// validate trims input and checks the required fields and the cron spec.
+func (req *jobRequest) validate() (enabled bool, err string) {
+	req.Name = strings.TrimSpace(req.Name)
+	req.Kind = strings.TrimSpace(req.Kind)
+	req.Schedule = strings.TrimSpace(req.Schedule)
+	if req.Name == "" {
+		return false, "name is required"
+	}
+	if req.Kind == "" {
+		req.Kind = "task"
+	}
+	if verr := schedule.Valid(req.Schedule); verr != nil {
+		return false, verr.Error()
+	}
+	en := true
+	if req.Enabled != nil {
+		en = *req.Enabled
+	}
+	return en, ""
+}
+
+func (s *Server) createJob(c *gin.Context) {
+	var req jobRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	enabled, verr := req.validate()
+	if verr != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": verr})
+		return
+	}
+	job, err := s.deps.Store.CreateJob(req.Name, req.Kind, req.Schedule, enabled)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	view, err := s.toJobView(job)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, view)
+}
+
+func (s *Server) getJob(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	job, err := s.deps.Store.GetJob(id)
+	if err == store.ErrNotFound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	view, err := s.toJobView(job)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, view)
+}
+
+func (s *Server) updateJob(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	var req jobRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	enabled, verr := req.validate()
+	if verr != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": verr})
+		return
+	}
+	job, err := s.deps.Store.UpdateJob(id, req.Name, req.Kind, req.Schedule, enabled)
+	if err == store.ErrNotFound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	view, err := s.toJobView(job)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, view)
+}
+
+func (s *Server) deleteJob(c *gin.Context) {
+	id, ok := parseID(c)
+	if !ok {
+		return
+	}
+	err := s.deps.Store.DeleteJob(id)
+	if err == store.ErrNotFound {
+		c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// parseID extracts the :id path param, writing a 400 and returning false on
+// malformed input.
+func parseID(c *gin.Context) (int64, bool) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return 0, false
+	}
+	return id, true
 }
 
 type listRunsResponse struct {

--- a/go-react-admin/internal/web/web_test.go
+++ b/go-react-admin/internal/web/web_test.go
@@ -38,7 +38,7 @@ func newTestServer(t *testing.T) (http.Handler, int64) {
 	t.Cleanup(func() { _ = st.Close() })
 	logs, _ := persistlog.New(t.TempDir())
 
-	job, _ := st.CreateJob("nightly", "batch", true)
+	job, _ := st.CreateJob("nightly", "batch", "@every 1m", true)
 	start := time.Now().UTC()
 	run, _ := st.CreateRun(job.ID, start)
 	pid, _ := st.AddPhase(run.ID, 0, "prepare", start)
@@ -275,3 +275,150 @@ func TestSPAFallback(t *testing.T) {
 }
 
 func itoa(n int64) string { return strconv.FormatInt(n, 10) }
+
+func reqJSON(h http.Handler, method, target, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, target, nil)
+	} else {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	h.ServeHTTP(rec, r)
+	return rec
+}
+
+func TestListJobs(t *testing.T) {
+	h, _ := newTestServer(t)
+	rec := do(h, "/api/jobs")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp struct {
+		Items []struct {
+			Name     string `json:"name"`
+			Schedule string `json:"schedule"`
+			RunCount int    `json:"runCount"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatal("expected at least one job")
+	}
+}
+
+func TestCreateJob_ValidatesCron(t *testing.T) {
+	h, _ := newTestServer(t)
+
+	// invalid cron rejected
+	if rec := reqJSON(h, http.MethodPost, "/api/jobs", `{"name":"x","schedule":"nope"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid cron status = %d, want 400", rec.Code)
+	}
+	// missing name rejected
+	if rec := reqJSON(h, http.MethodPost, "/api/jobs", `{"schedule":"@every 1m"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing name status = %d, want 400", rec.Code)
+	}
+	// valid create
+	rec := reqJSON(h, http.MethodPost, "/api/jobs", `{"name":"new","kind":"task","schedule":"@every 30s","enabled":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestJobLifecycle_UpdateAndDelete(t *testing.T) {
+	h, _ := newTestServer(t)
+	rec := reqJSON(h, http.MethodPost, "/api/jobs", `{"name":"lc","schedule":"@every 1m"}`)
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	if created.ID == 0 {
+		t.Fatal("no id returned")
+	}
+
+	// get
+	if rec := do(h, "/api/jobs/"+itoa(created.ID)); rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d", rec.Code)
+	}
+	// update
+	if rec := reqJSON(h, http.MethodPut, "/api/jobs/"+itoa(created.ID), `{"name":"lc2","schedule":"@hourly","enabled":false}`); rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	// delete
+	if rec := reqJSON(h, http.MethodDelete, "/api/jobs/"+itoa(created.ID), ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d", rec.Code)
+	}
+	// now gone
+	if rec := do(h, "/api/jobs/"+itoa(created.ID)); rec.Code != http.StatusNotFound {
+		t.Errorf("get after delete = %d, want 404", rec.Code)
+	}
+}
+
+func TestJob_NotFoundAndBadID(t *testing.T) {
+	h, _ := newTestServer(t)
+	if rec := do(h, "/api/jobs/9999"); rec.Code != http.StatusNotFound {
+		t.Errorf("missing get = %d, want 404", rec.Code)
+	}
+	if rec := do(h, "/api/jobs/abc"); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id = %d, want 400", rec.Code)
+	}
+	if rec := reqJSON(h, http.MethodPut, "/api/jobs/9999", `{"name":"x","schedule":"@every 1m"}`); rec.Code != http.StatusNotFound {
+		t.Errorf("update missing = %d, want 404", rec.Code)
+	}
+	if rec := reqJSON(h, http.MethodDelete, "/api/jobs/9999", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("delete missing = %d, want 404", rec.Code)
+	}
+}
+
+func TestCreateJob_DefaultsKindAndComputesNextRun(t *testing.T) {
+	h, _ := newTestServer(t)
+	rec := reqJSON(h, http.MethodPost, "/api/jobs", `{"name":"nokind","schedule":"@every 30s"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var view struct {
+		NextRunAt *string `json:"nextRunAt"`
+		Kind      string  `json:"kind"`
+		RunCount  int     `json:"runCount"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if view.Kind != "task" {
+		t.Errorf("kind = %q, want defaulted 'task'", view.Kind)
+	}
+	if view.NextRunAt == nil {
+		t.Error("nextRunAt should be computed from the schedule")
+	}
+	if view.RunCount != 0 {
+		t.Errorf("runCount = %d, want 0 for a new job", view.RunCount)
+	}
+}
+
+func TestCreateJob_BadBody(t *testing.T) {
+	h, _ := newTestServer(t)
+	if rec := reqJSON(h, http.MethodPost, "/api/jobs", `{not json`); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad body status = %d, want 400", rec.Code)
+	}
+}
+
+func TestQueryParamFallbacks(t *testing.T) {
+	h, _ := newTestServer(t)
+
+	// non-numeric page/page_size fall back to defaults (atoiDefault error branch)
+	if rec := do(h, "/api/runs?page=abc&page_size=xyz"); rec.Code != http.StatusOK {
+		t.Errorf("bad paging status = %d, want 200 (fallback)", rec.Code)
+	}
+
+	// explicit valid from/to (parseTimeDefault success branch)
+	if rec := do(h, "/api/metrics/aggregate?from=2026-06-16T00:00:00Z&to=2026-06-16T12:00:00Z&bucket=1h"); rec.Code != http.StatusOK {
+		t.Errorf("explicit range status = %d, want 200", rec.Code)
+	}
+	// garbage from/to fall back to defaults (parseTimeDefault error branch)
+	if rec := do(h, "/api/metrics/aggregate?from=nope&to=nope"); rec.Code != http.StatusOK {
+		t.Errorf("garbage range status = %d, want 200 (fallback)", rec.Code)
+	}
+}

--- a/go-react-admin/internal/worker/worker.go
+++ b/go-react-admin/internal/worker/worker.go
@@ -1,7 +1,7 @@
-// Package worker is the background daemon half of the single binary. It is the
-// example "jobs/runs" domain: on each tick it executes a job, producing a run
-// with phases, per-phase metrics, and JSONL log lines so every admin-console
-// screen has data to display.
+// Package worker is the background daemon half of the single binary. It is a
+// cron scheduler over the example "jobs/runs" domain: on every check tick it
+// runs each enabled job whose schedule is due, producing a run with phases,
+// per-phase metrics, and JSONL log lines so every admin-console screen has data.
 package worker
 
 import (
@@ -13,26 +13,25 @@ import (
 
 	"go-react-admin/internal/observability"
 	"go-react-admin/internal/persistlog"
+	"go-react-admin/internal/schedule"
 	"go-react-admin/internal/store"
 )
 
 // phaseNames are the steps every run walks through, in order.
 var phaseNames = []string{"prepare", "execute", "report"}
 
-// Daemon periodically executes jobs and records runs until ctx is canceled.
+// Daemon evaluates job schedules on a fixed check interval and runs due jobs.
 type Daemon struct {
 	store    *store.Store
 	logs     *persistlog.Writer
 	metrics  *observability.Metrics
 	rng      *rand.Rand
-	interval time.Duration
-	step     time.Duration
-	next     int
+	interval time.Duration // how often schedules are evaluated
+	step     time.Duration // per-phase delay (0 in tests)
 }
 
-// New returns a Daemon. deps may be nil only in the skeleton; in production the
-// server wires a real store, log writer, and metrics. New seeds example jobs if
-// the store is empty.
+// New returns a Daemon. interval is the schedule-check cadence. New seeds a few
+// example jobs (with cron schedules) the first time the store is used.
 func New(interval, step time.Duration, st *store.Store, logs *persistlog.Writer, m *observability.Metrics) *Daemon {
 	d := &Daemon{
 		interval: interval,
@@ -46,7 +45,7 @@ func New(interval, step time.Duration, st *store.Store, logs *persistlog.Writer,
 	return d
 }
 
-// seed inserts a couple of example jobs the first time the store is used.
+// seed inserts example jobs (with schedules) the first time the store is used.
 func (d *Daemon) seed() {
 	if d.store == nil {
 		return
@@ -59,49 +58,75 @@ func (d *Daemon) seed() {
 	if len(jobs) > 0 {
 		return
 	}
-	for _, j := range []struct{ name, kind string }{
-		{"nightly-export", "batch"},
-		{"metrics-rollup", "aggregate"},
-		{"cleanup-temp", "maintenance"},
+	for _, j := range []struct{ name, kind, schedule string }{
+		{"demo-sync", "sync", "@every 20s"}, // frequent, keeps the console lively
+		{"nightly-export", "batch", "0 2 * * *"},
+		{"hourly-rollup", "aggregate", "@hourly"},
 	} {
-		if _, err := d.store.CreateJob(j.name, j.kind, true); err != nil {
+		if _, err := d.store.CreateJob(j.name, j.kind, j.schedule, true); err != nil {
 			slog.Error("worker seed: create job", "error", err)
 		}
 	}
 }
 
-// Run blocks, executing a job on every tick, until ctx is canceled.
+// Run blocks, evaluating schedules every interval, until ctx is canceled.
 func (d *Daemon) Run(ctx context.Context) error {
 	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()
 
-	slog.Info("worker started", "interval", d.interval)
+	slog.Info("worker started", "check_interval", d.interval)
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Info("worker stopped")
 			return nil
 		case <-ticker.C:
-			if _, err := d.RunOnce(ctx); err != nil {
-				slog.Error("worker run failed", "error", err)
+			d.evaluate(ctx, time.Now().UTC())
+		}
+	}
+}
+
+// evaluate runs every enabled job whose schedule is due at `now`.
+func (d *Daemon) evaluate(ctx context.Context, now time.Time) {
+	jobs, err := d.store.ListJobs()
+	if err != nil {
+		slog.Error("worker evaluate: list jobs", "error", err)
+		return
+	}
+	for _, job := range jobs {
+		if !job.Enabled {
+			continue
+		}
+		if d.due(job, now) {
+			if _, err := d.execute(ctx, job); err != nil {
+				slog.Error("worker execute failed", "job", job.Name, "error", err)
 			}
 		}
 	}
 }
 
-// RunOnce executes a single job end to end and returns the resulting run. It is
-// exported so tests can drive one deterministic cycle without a ticker.
-func (d *Daemon) RunOnce(ctx context.Context) (store.Run, error) {
-	jobs, err := d.store.ListJobs()
+// due reports whether job's schedule fires at or before `now`, given its last
+// run (or creation time for a job that has never run).
+func (d *Daemon) due(job store.Job, now time.Time) bool {
+	sched, err := schedule.Parse(job.Schedule)
 	if err != nil {
-		return store.Run{}, fmt.Errorf("list jobs: %w", err)
+		slog.Warn("worker: invalid schedule", "job", job.Name, "schedule", job.Schedule, "error", err)
+		return false
 	}
-	if len(jobs) == 0 {
-		return store.Run{}, fmt.Errorf("no jobs to run")
+	last, err := d.store.LastRunStart(job.ID)
+	if err != nil {
+		slog.Error("worker: last run lookup", "job", job.Name, "error", err)
+		return false
 	}
-	job := jobs[d.next%len(jobs)]
-	d.next++
+	base := job.CreatedAt
+	if last != nil {
+		base = *last
+	}
+	return !sched.Next(base).After(now)
+}
 
+// execute runs a single job end to end and returns the resulting run.
+func (d *Daemon) execute(ctx context.Context, job store.Job) (store.Run, error) {
 	start := time.Now().UTC()
 	run, err := d.store.CreateRun(job.ID, start)
 	if err != nil {
@@ -127,7 +152,6 @@ func (d *Daemon) RunOnce(ctx context.Context) (store.Run, error) {
 
 		d.sleep(ctx)
 
-		// Emit a token-like metric sample for the phase.
 		tokens := float64(50 + d.rng.Intn(450))
 		if err := d.store.AddMetric(run.ID, "tokens", tokens, time.Now().UTC()); err != nil {
 			return run, err

--- a/go-react-admin/internal/worker/worker_test.go
+++ b/go-react-admin/internal/worker/worker_test.go
@@ -22,12 +22,11 @@ func newDaemon(t *testing.T) (*Daemon, *store.Store, *persistlog.Writer) {
 	if err != nil {
 		t.Fatalf("persistlog.New: %v", err)
 	}
-	// step 0 → no per-phase sleeps, deterministic + fast.
 	d := New(time.Hour, 0, st, logs, observability.New())
 	return d, st, logs
 }
 
-func TestNew_SeedsJobs(t *testing.T) {
+func TestNew_SeedsJobsWithSchedules(t *testing.T) {
 	_, st, _ := newDaemon(t)
 	jobs, err := st.ListJobs()
 	if err != nil {
@@ -36,115 +35,76 @@ func TestNew_SeedsJobs(t *testing.T) {
 	if len(jobs) == 0 {
 		t.Fatal("expected seeded jobs")
 	}
+	for _, j := range jobs {
+		if j.Schedule == "" {
+			t.Errorf("seeded job %q has no schedule", j.Name)
+		}
+	}
 }
 
-func TestRunOnce_ProducesRunWithPhasesMetricsLogs(t *testing.T) {
+func TestExecute_ProducesRunWithPhasesMetricsLogs(t *testing.T) {
 	d, st, logs := newDaemon(t)
+	job, _ := st.CreateJob("once", "task", "@every 1s", true)
 
-	run, err := d.RunOnce(context.Background())
+	run, err := d.execute(context.Background(), job)
 	if err != nil {
-		t.Fatalf("RunOnce: %v", err)
+		t.Fatalf("execute: %v", err)
 	}
 	if run.FinishedAt == nil {
 		t.Error("run should be finished")
 	}
-	if run.Status != store.StatusSucceeded && run.Status != store.StatusFailed {
-		t.Errorf("terminal status = %q", run.Status)
+	phases, _ := st.ListPhases(run.ID)
+	if len(phases) == 0 {
+		t.Error("expected phases")
 	}
-
-	phases, err := st.ListPhases(run.ID)
-	if err != nil || len(phases) == 0 {
-		t.Fatalf("expected phases, got %v (%v)", phases, err)
-	}
-
-	lines, err := logs.Read(run.ID)
-	if err != nil || len(lines) == 0 {
-		t.Fatalf("expected log lines, got %v (%v)", lines, err)
-	}
-
-	// Metrics should have been recorded for the run window.
-	series, err := st.AggregateMetrics(run.StartedAt.Add(-time.Minute), time.Now().Add(time.Minute), 0)
-	if err != nil {
-		t.Fatalf("AggregateMetrics: %v", err)
-	}
-	if len(series) == 0 {
-		t.Error("expected at least one metric series")
+	lines, _ := logs.Read(run.ID)
+	if len(lines) == 0 {
+		t.Error("expected log lines")
 	}
 }
 
-func TestRunOnce_RoundRobinsJobs(t *testing.T) {
+func TestDue(t *testing.T) {
 	d, st, _ := newDaemon(t)
-	jobs, _ := st.ListJobs()
 
-	seen := map[int64]bool{}
-	for i := 0; i < len(jobs); i++ {
-		run, err := d.RunOnce(context.Background())
-		if err != nil {
-			t.Fatalf("RunOnce: %v", err)
-		}
-		seen[run.JobID] = true
+	// A job that runs every second, created in the past, is due now.
+	jobDue, _ := st.CreateJob("due", "task", "@every 1s", true)
+	if !d.due(jobDue, jobDue.CreatedAt.Add(2*time.Second)) {
+		t.Error("expected job to be due")
 	}
-	if len(seen) != len(jobs) {
-		t.Errorf("round-robin covered %d jobs, want %d", len(seen), len(jobs))
-	}
-}
 
-func TestRunOnce_ProducesBothSucceededAndFailed(t *testing.T) {
-	// The RNG is seeded deterministically (seed 1), so a fixed number of runs
-	// reliably exercises both the success and failure branches.
-	d, _, _ := newDaemon(t)
-	var sawSucceeded, sawFailed bool
-	for i := 0; i < 30; i++ {
-		run, err := d.RunOnce(context.Background())
-		if err != nil {
-			t.Fatalf("RunOnce: %v", err)
-		}
-		switch run.Status {
-		case store.StatusSucceeded:
-			sawSucceeded = true
-		case store.StatusFailed:
-			sawFailed = true
-		}
+	// A far-future daily job created now is not due immediately.
+	jobNotDue, _ := st.CreateJob("nightly", "batch", "0 2 * * *", true)
+	if d.due(jobNotDue, jobNotDue.CreatedAt.Add(time.Minute)) {
+		t.Error("nightly job should not be due a minute after creation")
 	}
-	if !sawSucceeded || !sawFailed {
-		t.Errorf("over 30 runs: succeeded=%v failed=%v, want both", sawSucceeded, sawFailed)
+
+	// Invalid schedule is never due.
+	bad := store.Job{ID: jobDue.ID, Schedule: "not a cron", CreatedAt: jobDue.CreatedAt}
+	if d.due(bad, time.Now()) {
+		t.Error("invalid schedule should not be due")
 	}
 }
 
-func TestRunOnce_RespectsPerPhaseDelay(t *testing.T) {
-	st, _ := store.Open(filepath.Join(t.TempDir(), "d.db"))
-	t.Cleanup(func() { _ = st.Close() })
-	logs, _ := persistlog.New(t.TempDir())
-	d := New(time.Hour, 5*time.Millisecond, st, logs, observability.New())
-
-	start := time.Now()
-	if _, err := d.RunOnce(context.Background()); err != nil {
-		t.Fatalf("RunOnce: %v", err)
+func TestEvaluate_RunsOnlyDueEnabledJobs(t *testing.T) {
+	d, st, _ := newDaemon(t)
+	// Clear seeds for a deterministic set.
+	for _, j := range mustList(t, st) {
+		_ = st.DeleteJob(j.ID)
 	}
-	// Three phases × 5ms of sleep means the cycle can't be instantaneous.
-	if elapsed := time.Since(start); elapsed < 5*time.Millisecond {
-		t.Errorf("elapsed = %v, expected per-phase delay to apply", elapsed)
+
+	dueJob, _ := st.CreateJob("due", "task", "@every 1s", true)
+	_, _ = st.CreateJob("disabled", "task", "@every 1s", false)
+	_, _ = st.CreateJob("future", "task", "0 2 * * *", true)
+
+	d.evaluate(context.Background(), time.Now().Add(5*time.Second))
+
+	dueRuns, _ := st.CountRunsByJob(dueJob.ID)
+	if dueRuns != 1 {
+		t.Errorf("due job runs = %d, want 1", dueRuns)
 	}
-}
-
-func TestRunOnce_CanceledContextStopsSleep(t *testing.T) {
-	st, _ := store.Open(filepath.Join(t.TempDir(), "c.db"))
-	t.Cleanup(func() { _ = st.Close() })
-	logs, _ := persistlog.New(t.TempDir())
-	d := New(time.Hour, time.Hour, st, logs, observability.New())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already canceled: sleep should return immediately
-
-	done := make(chan struct{})
-	go func() {
-		_, _ = d.RunOnce(ctx)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("RunOnce did not honor canceled context during phase sleep")
+	all, _, _ := st.ListRuns(store.RunFilter{}, 1, 100)
+	if len(all) != 1 {
+		t.Errorf("total runs = %d, want 1 (only the due+enabled job)", len(all))
 	}
 }
 
@@ -167,5 +127,53 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Run() did not return after cancel")
+	}
+}
+
+func mustList(t *testing.T, st *store.Store) []store.Job {
+	t.Helper()
+	jobs, err := st.ListJobs()
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	return jobs
+}
+
+func TestExecute_ProducesBothSucceededAndFailed(t *testing.T) {
+	d, st, _ := newDaemon(t)
+	job, _ := st.CreateJob("mix", "task", "@every 1s", true)
+	var sawOK, sawFail bool
+	for i := 0; i < 30; i++ {
+		run, err := d.execute(context.Background(), job)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		switch run.Status {
+		case store.StatusSucceeded:
+			sawOK = true
+		case store.StatusFailed:
+			sawFail = true
+		}
+	}
+	if !sawOK || !sawFail {
+		t.Errorf("over 30 runs: ok=%v fail=%v, want both", sawOK, sawFail)
+	}
+}
+
+func TestExecute_CanceledContextStopsSleep(t *testing.T) {
+	st, _ := store.Open(filepath.Join(t.TempDir(), "c.db"))
+	t.Cleanup(func() { _ = st.Close() })
+	logs, _ := persistlog.New(t.TempDir())
+	d := New(time.Hour, time.Hour, st, logs, observability.New())
+	job, _ := st.CreateJob("slow", "task", "@every 1s", true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() { _, _ = d.execute(ctx, job); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("execute did not honor canceled context during phase sleep")
 	}
 }


### PR DESCRIPTION
## 概要

worker のハードコード round-robin（ダミー job を機械的に回すだけ）を廃止し、**job ごとの cron スケジュール評価**に置き換える。**job の CRUD 画面**と **job 別の実行履歴**を追加する。

## 関連 Issue

Closes: #261
Refs: #246

## やったこと

### backend
- `internal/schedule`: `robfig/cron/v3` ラッパ。標準 5 フィールド / optional-seconds / descriptor（`@every 20s` / `@hourly`）を受理。
- `internal/store`: `jobs.schedule` 追加（**idempotent な `addColumnIfMissing` migration** で既存 DB も移行）。`GetJob`/`UpdateJob`/`DeleteJob`（runs/phases/metrics を **tx で cascade 削除**）/`LastRunStart`/`CountRunsByJob`。
- `internal/worker`: round-robin → **cron 評価ループ**。チェック間隔（`worker_interval`）ごとに enabled な各 job を `due(schedule.Next(lastRun ?? createdAt) <= now)` で判定して実行。
- `internal/web`: jobs CRUD + cron バリデーション。`jobView` に `lastRunAt`/`nextRunAt`/`runCount`。job 別履歴は既存 `GET /api/runs?job_id=` を再利用。

### frontend
- サイドバーに **Jobs**。**一覧**（DataTable + KindBadge + StatusBadge + New/Edit/Delete）/ **作成・編集フォーム**（cron 例ヒント・サーバ検証エラー表示）/ **詳細**（job 情報 + その job の実行履歴 DataTable+Pagination → run 詳細）。
- `api/jobs`・`hooks/useJobs`・schemas/types/mock・各テスト。

## 動作確認（実バイナリ）

```
seed: demo-sync(@every 20s) / nightly-export(0 2 * * *) / hourly-rollup(@hourly)
→ 25s 後: demo-sync runs=1、@every 5s で作った job runs=2、nightly/hourly は未実行（due でない）
GET /api/runs?job_id=<id> → その job の履歴のみ
DELETE /api/jobs/<id> → 204、runs も cascade 削除（0 件）
POST 不正 cron → 400
```

## テスト

- [x] go test **80.5%** / golangci-lint **0** / vitest **32** / eslint / tsc / vite build すべて緑

## チェックリスト

- [x] `Closes:` #261 / 親 #246 は `Refs:`
- [x] 機密情報なし
- [x] Conventional Commits
- [ ] base = `main` → **#259（PR #260, config）にスタック**。先行 PR が main に入れば自動 retarget。マージ順: #258 → #260 → #261。
- [x] schema 変更あり（jobs.schedule。idempotent migration 済み）

## 補足 / レビュー観点

- スケジューラは「チェック間隔ごとに due な job を最大 1 回実行」方式。`worker_interval`（#259 で編集可）が**スケジューラのチェック間隔**になった（意味変更を README 反映予定→本 PR では worker のドキュメントは最小）。
- cron 解像度: descriptor `@every Ns` で秒オーダーも可。標準 cron は分解像度。
- DELETE は runs/phases/metrics を tx で cascade。jsonl ログファイルは孤立するが run 行が消えるため到達不能（`make clean` で消える）。