### PR TITLE
fix(go-react-admin): nested route の API パス解決・サイドバー開閉・select 矢印位置

### DIFF
--- a/go-react-admin/frontend/src/api/client.ts
+++ b/go-react-admin/frontend/src/api/client.ts
@@ -2,8 +2,14 @@ import ky from "ky";
 import { logger } from "@/lib/logger";
 
 // .env.production / .env.development set VITE_API_BASE_URL="" so prod (monolith)
-// and dev (Vite proxy) both use same-origin /api. Tests fall back to localhost:8080.
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+// and dev (Vite proxy) both use same-origin /api. Tests set an absolute URL.
+//
+// Empty → "/" (root-absolute), NOT "" — with an empty prefix, ky would resolve
+// relative request paths like "api/jobs/2" against the current page URL, so on a
+// nested route (e.g. /jobs/2/edit) the request would wrongly go to
+// /jobs/2/api/jobs/2 and hit the SPA fallback (HTML) instead of the API. "/"
+// pins every request to the origin root → "/api/jobs/2".
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/";
 
 export const apiClient = ky.create({
   prefixUrl: API_BASE_URL,

--- a/go-react-admin/frontend/src/components/Layout.test.tsx
+++ b/go-react-admin/frontend/src/components/Layout.test.tsx
@@ -22,3 +22,27 @@ describe("Layout", () => {
     expect(screen.getByText("child content")).toBeInTheDocument();
   });
 });
+
+describe("Layout sidebar collapse", () => {
+  it("toggles the sidebar labels via the collapse button", async () => {
+    const userEvent = (await import("@testing-library/user-event")).default;
+    const user = userEvent.setup();
+    render(
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<div>child</div>} />
+        </Route>
+      </Routes>,
+      { initialEntries: ["/"] }
+    );
+
+    // expanded by default → labels visible
+    expect(screen.getByText("Runs")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    // collapsed → text labels hidden, expand control available
+    expect(screen.queryByText("Runs")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+  });
+});

--- a/go-react-admin/frontend/src/components/Layout.tsx
+++ b/go-react-admin/frontend/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import {
   Activity,
@@ -5,6 +6,8 @@ import {
   CalendarClock,
   FileText,
   ListChecks,
+  PanelLeftClose,
+  PanelLeftOpen,
   Settings,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -23,14 +26,71 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/config", label: "Config", icon: Settings },
 ];
 
+const COLLAPSE_KEY = "admin.sidebar.collapsed";
+
+// localStorage may be unavailable (SSR, some test envs), so access it defensively.
+function readCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(COLLAPSE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeCollapsed(value: boolean): void {
+  try {
+    window.localStorage.setItem(COLLAPSE_KEY, value ? "1" : "0");
+  } catch {
+    // ignore persistence failures
+  }
+}
+
 export function Layout() {
+  const [collapsed, setCollapsed] = useState<boolean>(readCollapsed);
+
+  const toggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      writeCollapsed(next);
+      return next;
+    });
+  };
+
   return (
     <div className="flex min-h-screen bg-slate-50 text-slate-900">
-      <aside className="flex w-56 shrink-0 flex-col border-r border-slate-200 bg-white">
-        <div className="flex items-center gap-2 px-4 py-4 text-lg font-semibold">
-          <Activity className="h-5 w-5 text-indigo-500" />
-          <span>Admin Console</span>
+      <aside
+        className={cn(
+          "flex shrink-0 flex-col border-r border-slate-200 bg-white transition-all duration-200",
+          collapsed ? "w-16" : "w-56"
+        )}
+      >
+        <div
+          className={cn(
+            "flex items-center px-3 py-4",
+            collapsed ? "justify-center" : "justify-between"
+          )}
+        >
+          {!collapsed && (
+            <div className="flex items-center gap-2 text-lg font-semibold">
+              <Activity className="h-5 w-5 text-indigo-500" />
+              <span>Admin Console</span>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-expanded={!collapsed}
+            className="rounded-md p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+          >
+            {collapsed ? (
+              <PanelLeftOpen className="h-5 w-5" />
+            ) : (
+              <PanelLeftClose className="h-5 w-5" />
+            )}
+          </button>
         </div>
+
         <nav className="flex flex-col gap-1 px-2">
           {NAV_ITEMS.map((item) => {
             const Icon = item.icon;
@@ -38,17 +98,19 @@ export function Layout() {
               <NavLink
                 key={item.to}
                 to={item.to}
+                title={collapsed ? item.label : undefined}
                 className={({ isActive }) =>
                   cn(
                     "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    collapsed && "justify-center px-0",
                     isActive
                       ? "bg-indigo-50 text-indigo-700"
                       : "text-slate-600 hover:bg-slate-100"
                   )
                 }
               >
-                <Icon className="h-4 w-4" />
-                {item.label}
+                <Icon className="h-4 w-4 shrink-0" />
+                {!collapsed && item.label}
               </NavLink>
             );
           })}

--- a/shared-react-ui/src/admin/metrics-filters.tsx
+++ b/shared-react-ui/src/admin/metrics-filters.tsx
@@ -32,7 +32,15 @@ export function MetricsFilters({
           <select
             value={field.value}
             onChange={(e) => onChange(field.name, e.target.value)}
-            className="h-9 rounded-md border border-slate-300 bg-white px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-400"
+            // appearance-none + a custom right-aligned chevron: native select
+            // arrows render inconsistently (and can look misplaced on Linux/GTK).
+            className="h-9 appearance-none rounded-md border border-slate-300 bg-white bg-no-repeat py-0 pl-3 pr-9 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-400"
+            style={{
+              backgroundImage:
+                "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m4 6 4 4 4-4'/%3E%3C/svg%3E\")",
+              backgroundPosition: "right 0.625rem center",
+              backgroundSize: "1rem",
+            }}
           >
             {field.options.map((option) => (
               <option key={option.value} value={option.value}>


### PR DESCRIPTION
## 概要

ユーザー報告の不具合 3 点を修正する。

1. **`/jobs/:id/edit` 等で「Unexpected token '<', \"<!doctype \"... is not valid JSON」**
   - 原因: `api/client` の `prefixUrl` が空文字。ky が相対パス（`api/jobs/2`）を**現在ページ URL 基準**で解決するため、nested route（`/jobs/2/edit`）では `/jobs/2/api/jobs/2` に飛び、SPA fallback の HTML を取得してしまう。
   - 修正: `prefixUrl` を `"/"`（origin ルート固定）に。→ 常に `/api/jobs/2`。全 nested route（`/jobs/:id`, `/jobs/:id/edit`, `/runs/:id`）が直る。テストは絶対 URL を使うため影響なし。
2. **サイドバーを開閉可能に**（トグルボタン + `localStorage` 永続化、折りたたみ時はアイコンのみ + `title`）。
3. **select の下矢印が左寄りで不自然**（`shared-react-ui` の `MetricsFilters`）→ `appearance-none` + 右寄せのカスタム chevron に統一。

## 関連 Issue

Refs: #246

## 変更タイプ

- [x] fix: バグ修正

## 動作確認

- 実機: `/jobs/1/edit` が `/api/jobs/1`（`application/json`）を取得することを確認（修正前は `/jobs/1/api/jobs/1` → HTML）。
- サイドバーのトグルで折りたたみ↔展開、リロードしても状態維持。
- Runs/Metrics のフィルタ select の矢印が右に統一。

## テスト

- [x] frontend: tsc / eslint / prettier / **vitest 33** / build 緑。shared-react-ui tsc 緑。
- [x] サイドバー開閉のテストを追加。

## チェックリスト

- [x] `Refs:` 使用（親 issue は close しない）
- [x] 機密情報なし
- [x] Conventional Commits
- [x] base = `main`

## 補足

- `MetricsFilters` は `shared-react-ui` の共有コンポーネント。修正はソース（`shared-react-ui/src/admin`）に入れ、`go-react-admin/frontend` へは compose で反映（composed コピーは gitignore）。
- これは merged 済みテンプレートの実バグ修正（全 nested route に影響）。