### PR TITLE
feat(go-react-admin): DataTable 再設計（固定幅/省略+ツールチップ/列フィルタ）と詳細を半オーバーレイ化

### DIFF
--- a/go-react-admin/frontend/src/components/JobDetailContent.tsx
+++ b/go-react-admin/frontend/src/components/JobDetailContent.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { DataTable, type DataTableColumn } from "@/components/admin/data-table";
+import { Pagination } from "@/components/admin/pagination";
+import { StatusBadge } from "@/components/admin/status-badge";
+import { Button } from "@/components/ui/button";
+import { useJob, useDeleteJob } from "@/hooks/useJobs";
+import { useRuns } from "@/hooks/useRuns";
+import { statusTone, formatDuration } from "@/lib/status";
+import type { JobView } from "@/types/job";
+import type { Run } from "@/types/run";
+
+const PAGE_SIZE = 20;
+
+// JobDetailContent renders a job's info + its run history. Used inside the
+// drawer (from the Jobs list) and the full-page route /jobs/:id. Run-history
+// rows navigate to the full /runs/:id page (avoids nesting drawers).
+export function JobDetailContent({
+  jobId,
+  onEdit,
+  onDeleted,
+}: {
+  jobId: number;
+  onEdit?: () => void;
+  onDeleted?: () => void;
+}) {
+  const { data, isLoading, isError, error } = useJob(jobId);
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500">Loading…</div>;
+  }
+  if (isError || !data) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+        Failed to load job: {(error as Error)?.message ?? "not found"}
+      </div>
+    );
+  }
+
+  return <JobBody job={data} onEdit={onEdit} onDeleted={onDeleted} />;
+}
+
+function JobBody({
+  job,
+  onEdit,
+  onDeleted,
+}: {
+  job: JobView;
+  onEdit?: () => void;
+  onDeleted?: () => void;
+}) {
+  const navigate = useNavigate();
+  const deleteJob = useDeleteJob();
+  const [page, setPage] = useState(1);
+
+  const { data: runs, isLoading: runsLoading } = useRuns({
+    jobId: job.id,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+
+  const onDelete = () => {
+    if (!window.confirm(`Delete job "${job.name}"?`)) return;
+    deleteJob.mutate(job.id, { onSuccess: () => onDeleted?.() });
+  };
+
+  const columns: DataTableColumn<Run>[] = [
+    { key: "id", header: "ID", width: "5rem", align: "right", cell: (row) => row.id },
+    {
+      key: "status",
+      header: "Status",
+      width: "9rem",
+      cell: (row) => <StatusBadge tone={statusTone(row.status)} label={row.status} />,
+    },
+    {
+      key: "startedAt",
+      header: "Started",
+      cell: (row) => row.startedAt,
+      title: (row) => row.startedAt,
+    },
+    {
+      key: "duration",
+      header: "Duration",
+      width: "7rem",
+      align: "right",
+      cell: (row) => formatDuration(row.startedAt, row.finishedAt),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-lg font-semibold">{job.name}</h2>
+          <StatusBadge
+            tone={job.enabled ? "success" : "neutral"}
+            label={job.enabled ? "enabled" : "disabled"}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          {onEdit && (
+            <Button variant="outline" size="sm" onClick={onEdit}>
+              Edit
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDelete}
+            disabled={deleteJob.isPending}
+          >
+            Delete
+          </Button>
+        </div>
+      </header>
+
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+        <Field label="Kind" value={job.kind} />
+        <Field label="Schedule" value={job.schedule} mono />
+        <Field label="Runs" value={String(job.runCount)} />
+        <Field label="Last run" value={job.lastRunAt ?? "—"} />
+        <Field label="Next run" value={job.nextRunAt ?? "—"} />
+        <Field label="Created" value={job.createdAt} />
+      </dl>
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-slate-700">Run history</h3>
+        <DataTable<Run>
+          columns={columns}
+          rows={runs?.items ?? []}
+          getRowKey={(row) => row.id}
+          onRowClick={(row) => navigate(`/runs/${row.id}`)}
+          emptyMessage={runsLoading ? "Loading…" : "No runs yet"}
+        />
+        <Pagination
+          page={runs?.page ?? page}
+          pageSize={runs?.pageSize ?? PAGE_SIZE}
+          total={runs?.total ?? 0}
+          onPageChange={setPage}
+        />
+      </section>
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-slate-500">{label}</dt>
+      <dd className={mono ? "font-mono text-xs text-slate-700" : "text-slate-700"}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/go-react-admin/frontend/src/components/RunDetailContent.tsx
+++ b/go-react-admin/frontend/src/components/RunDetailContent.tsx
@@ -1,0 +1,68 @@
+import { StatusBadge } from "@/components/admin/status-badge";
+import { PhaseTimeline } from "@/components/admin/phase-timeline";
+import { EventTimeline } from "@/components/admin/event-timeline";
+import { LogViewer } from "@/components/LogViewer";
+import { useRun } from "@/hooks/useRuns";
+import { statusTone, formatDuration } from "@/lib/status";
+import type { AdminEvent, Phase } from "@/types/run";
+
+// RunDetailContent renders a run's detail (summary + timelines + logs). It is
+// used both inside the half-overlay drawer (from the Runs list) and by the
+// full-page route /runs/:id, so it owns no page chrome (no back link).
+export function RunDetailContent({ runId }: { runId: number }) {
+  const { data, isLoading, isError, error } = useRun(runId);
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500">Loading…</div>;
+  }
+  if (isError || !data) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+        Failed to load run: {(error as Error)?.message ?? "not found"}
+      </div>
+    );
+  }
+
+  const { run, phases, events, logs } = data;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-wrap items-center gap-3">
+        <h2 className="text-lg font-semibold">
+          Run #{run.id} &middot; {run.jobName}
+        </h2>
+        <StatusBadge tone={statusTone(run.status)} label={run.status} />
+        <span className="text-sm text-slate-500">
+          {formatDuration(run.startedAt, run.finishedAt)}
+        </span>
+      </header>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-sm font-medium text-slate-500">Phases</h3>
+        <PhaseTimeline<Phase>
+          phases={phases}
+          getKey={(p) => p.id}
+          getName={(p) => p.name}
+          getTone={(p) => statusTone(p.status)}
+          getDuration={(p) => formatDuration(p.startedAt, p.finishedAt)}
+        />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-sm font-medium text-slate-500">Events</h3>
+        <EventTimeline<AdminEvent>
+          items={events}
+          getKey={(e, i) => `${e.ts}-${i}`}
+          getTimestamp={(e) => e.ts}
+          getTitle={(e) => `${e.type} · ${e.phase}`}
+          getTone={(e) => statusTone(e.status)}
+        />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-sm font-medium text-slate-500">Logs</h3>
+        <LogViewer logs={logs} />
+      </section>
+    </div>
+  );
+}

--- a/go-react-admin/frontend/src/pages/JobDetailPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobDetailPage.tsx
@@ -1,148 +1,32 @@
-import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import { DataTable } from "@/components/admin/data-table";
-import { Pagination } from "@/components/admin/pagination";
-import { StatusBadge } from "@/components/admin/status-badge";
-import { Button } from "@/components/ui/button";
-import { useJob, useDeleteJob } from "@/hooks/useJobs";
-import { useRuns } from "@/hooks/useRuns";
-import { statusTone, formatDuration } from "@/lib/status";
-import type { JobView } from "@/types/job";
-import type { Run } from "@/types/run";
+import { JobDetailContent } from "@/components/JobDetailContent";
 
-const PAGE_SIZE = 20;
-
+// Full-page route for /jobs/:id (deep link). The list view opens the same
+// content in a drawer; here it gets page chrome (a back link).
 export function JobDetailPage() {
   const params = useParams<{ id: string }>();
-  const id = params.id ? Number(params.id) : undefined;
-  const { data, isLoading, isError, error } = useJob(id);
-
-  if (isLoading) {
-    return <div className="text-sm text-slate-500">Loading…</div>;
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="flex flex-col gap-4">
-        <BackLink />
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          Failed to load job: {(error as Error)?.message ?? "not found"}
-        </div>
-      </div>
-    );
-  }
-
-  return <JobDetail job={data} />;
-}
-
-function JobDetail({ job }: { job: JobView }) {
   const navigate = useNavigate();
-  const deleteJob = useDeleteJob();
-  const [page, setPage] = useState(1);
-
-  const { data: runs, isLoading: runsLoading } = useRuns({
-    jobId: job.id,
-    page,
-    pageSize: PAGE_SIZE,
-  });
-
-  const onDelete = () => {
-    if (!window.confirm(`Delete job "${job.name}"?`)) return;
-    deleteJob.mutate(job.id, { onSuccess: () => navigate("/jobs") });
-  };
-
-  const columns = [
-    { header: "ID", cell: (row: Run) => row.id, align: "right" as const },
-    {
-      header: "Status",
-      cell: (row: Run) => (
-        <StatusBadge tone={statusTone(row.status)} label={row.status} />
-      ),
-    },
-    { header: "Started", cell: (row: Run) => row.startedAt },
-    {
-      header: "Duration",
-      cell: (row: Run) => formatDuration(row.startedAt, row.finishedAt),
-      align: "right" as const,
-    },
-  ];
+  const id = params.id ? Number(params.id) : undefined;
 
   return (
     <div className="flex flex-col gap-6">
-      <BackLink />
-
-      <header className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-xl font-semibold">{job.name}</h1>
-          <StatusBadge
-            tone={job.enabled ? "success" : "neutral"}
-            label={job.enabled ? "enabled" : "disabled"}
-          />
-        </div>
-        <div className="flex items-center gap-2">
-          <Button asChild variant="outline" size="sm">
-            <Link to={`/jobs/${job.id}/edit`}>Edit</Link>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onDelete}
-            disabled={deleteJob.isPending}
-          >
-            Delete
-          </Button>
-        </div>
-      </header>
-
-      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
-        <Field label="Kind" value={job.kind} />
-        <Field label="Schedule" value={job.schedule} mono />
-        <Field label="Runs" value={String(job.runCount)} />
-        <Field label="Last run" value={job.lastRunAt ?? "—"} />
-        <Field label="Next run" value={job.nextRunAt ?? "—"} />
-        <Field label="Created" value={job.createdAt} />
-      </dl>
-
-      <section className="flex flex-col gap-3">
-        <h2 className="text-sm font-semibold text-slate-700">Run history</h2>
-        <DataTable<Run>
-          columns={columns}
-          rows={runs?.items ?? []}
-          getRowKey={(row) => row.id}
-          onRowClick={(row) => navigate(`/runs/${row.id}`)}
-          emptyMessage={runsLoading ? "Loading…" : "No runs yet"}
+      <Link
+        to="/jobs"
+        className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to jobs
+      </Link>
+      {id === undefined ? (
+        <div className="text-sm text-red-700">Invalid job id</div>
+      ) : (
+        <JobDetailContent
+          jobId={id}
+          onEdit={() => navigate(`/jobs/${id}/edit`)}
+          onDeleted={() => navigate("/jobs")}
         />
-        <Pagination
-          page={runs?.page ?? page}
-          pageSize={runs?.pageSize ?? PAGE_SIZE}
-          total={runs?.total ?? 0}
-          onPageChange={setPage}
-        />
-      </section>
+      )}
     </div>
-  );
-}
-
-function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <dt className="text-xs font-medium text-slate-500">{label}</dt>
-      <dd className={mono ? "font-mono text-xs text-slate-700" : "text-slate-700"}>
-        {value}
-      </dd>
-    </div>
-  );
-}
-
-function BackLink() {
-  return (
-    <Link
-      to="/jobs"
-      className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
-    >
-      <ArrowLeft className="h-4 w-4" />
-      Back to jobs
-    </Link>
   );
 }

--- a/go-react-admin/frontend/src/pages/JobsPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/JobsPage.test.tsx
@@ -24,3 +24,22 @@ describe("JobsPage", () => {
     expect(link).toHaveAttribute("href", "/jobs/new");
   });
 });
+
+describe("JobsPage interactions", () => {
+  it("opens a job detail drawer when a row is clicked", async () => {
+    const userEvent = (await import("@testing-library/user-event")).default;
+    const user = userEvent.setup();
+    render(<JobsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("nightly-export")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("nightly-export"));
+
+    // JobDetailContent loads inside the drawer → run history heading + Close.
+    await waitFor(() => {
+      expect(screen.getByText("Run history")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+});

--- a/go-react-admin/frontend/src/pages/JobsPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobsPage.tsx
@@ -1,69 +1,82 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";
-import { DataTable } from "@/components/admin/data-table";
+import { DataTable, type DataTableColumn } from "@/components/admin/data-table";
 import { StatusBadge } from "@/components/admin/status-badge";
 import { KindBadge } from "@/components/admin/kind-badge";
+import { Drawer } from "@/components/admin/drawer";
 import { Button } from "@/components/ui/button";
-import { useJobs, useDeleteJob } from "@/hooks/useJobs";
+import { JobDetailContent } from "@/components/JobDetailContent";
+import { useJobs } from "@/hooks/useJobs";
 import type { JobView } from "@/types/job";
+
+const ENABLED_OPTIONS = [
+  { value: "true", label: "Enabled" },
+  { value: "false", label: "Disabled" },
+];
 
 export function JobsPage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, error } = useJobs();
-  const deleteJob = useDeleteJob();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const onDelete = (job: JobView) => {
-    if (!window.confirm(`Delete job "${job.name}"?`)) return;
-    deleteJob.mutate(job.id);
-  };
-
-  const columns = [
-    { header: "Name", cell: (row: JobView) => row.name },
+  const columns: DataTableColumn<JobView>[] = [
     {
+      key: "name",
+      header: "Name",
+      width: "14rem",
+      cell: (row) => row.name,
+      title: (row) => row.name,
+      filter: { kind: "text", accessor: (row) => row.name, placeholder: "name…" },
+    },
+    {
+      key: "kind",
       header: "Kind",
-      cell: (row: JobView) => <KindBadge label={row.kind} />,
+      width: "9rem",
+      cell: (row) => <KindBadge label={row.kind} />,
+      filter: { kind: "text", accessor: (row) => row.kind, placeholder: "kind…" },
     },
     {
+      key: "schedule",
       header: "Schedule",
-      cell: (row: JobView) => <span className="font-mono text-xs">{row.schedule}</span>,
+      width: "12rem",
+      cell: (row) => <span className="font-mono text-xs">{row.schedule}</span>,
+      title: (row) => row.schedule,
     },
     {
+      key: "enabled",
       header: "Enabled",
-      cell: (row: JobView) => (
+      width: "9rem",
+      cell: (row) => (
         <StatusBadge
           tone={row.enabled ? "success" : "neutral"}
           label={row.enabled ? "enabled" : "disabled"}
         />
       ),
+      filter: {
+        kind: "select",
+        accessor: (row) => String(row.enabled),
+        options: ENABLED_OPTIONS,
+      },
     },
-    { header: "Last run", cell: (row: JobView) => row.lastRunAt ?? "—" },
-    { header: "Next run", cell: (row: JobView) => row.nextRunAt ?? "—" },
     {
+      key: "lastRunAt",
+      header: "Last run",
+      cell: (row) => row.lastRunAt ?? "—",
+      title: (row) => row.lastRunAt ?? "",
+    },
+    {
+      key: "nextRunAt",
+      header: "Next run",
+      cell: (row) => row.nextRunAt ?? "—",
+      title: (row) => row.nextRunAt ?? "",
+    },
+    {
+      key: "runCount",
       header: "Runs",
-      cell: (row: JobView) => row.runCount,
-      align: "right" as const,
-    },
-    {
-      header: "",
-      cell: (row: JobView) => (
-        <div
-          className="flex items-center justify-end gap-2"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Button asChild variant="outline" size="sm">
-            <Link to={`/jobs/${row.id}/edit`}>Edit</Link>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onDelete(row)}
-            disabled={deleteJob.isPending}
-          >
-            Delete
-          </Button>
-        </div>
-      ),
-      align: "right" as const,
+      width: "5rem",
+      align: "right",
+      cell: (row) => row.runCount,
     },
   ];
 
@@ -88,10 +101,24 @@ export function JobsPage() {
           columns={columns}
           rows={data?.items ?? []}
           getRowKey={(row) => row.id}
-          onRowClick={(row) => navigate(`/jobs/${row.id}`)}
+          onRowClick={(row) => setSelectedId(row.id)}
           emptyMessage={isLoading ? "Loading…" : "No jobs"}
         />
       )}
+
+      <Drawer
+        open={selectedId !== null}
+        onClose={() => setSelectedId(null)}
+        title={selectedId !== null ? "Job detail" : ""}
+      >
+        {selectedId !== null && (
+          <JobDetailContent
+            jobId={selectedId}
+            onEdit={() => navigate(`/jobs/${selectedId}/edit`)}
+            onDeleted={() => setSelectedId(null)}
+          />
+        )}
+      </Drawer>
     </div>
   );
 }

--- a/go-react-admin/frontend/src/pages/RunDetailPage.tsx
+++ b/go-react-admin/frontend/src/pages/RunDetailPage.tsx
@@ -1,87 +1,27 @@
 import { Link, useParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import { StatusBadge } from "@/components/admin/status-badge";
-import { PhaseTimeline } from "@/components/admin/phase-timeline";
-import { EventTimeline } from "@/components/admin/event-timeline";
-import { LogViewer } from "@/components/LogViewer";
-import { useRun } from "@/hooks/useRuns";
-import { statusTone, formatDuration } from "@/lib/status";
-import type { AdminEvent, Phase } from "@/types/run";
+import { RunDetailContent } from "@/components/RunDetailContent";
 
+// Full-page route for /runs/:id (deep link). The list view opens the same
+// content in a drawer; here it gets page chrome (a back link).
 export function RunDetailPage() {
   const params = useParams<{ id: string }>();
   const id = params.id ? Number(params.id) : undefined;
-  const { data, isLoading, isError, error } = useRun(id);
-
-  if (isLoading) {
-    return <div className="text-sm text-slate-500">Loading…</div>;
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="flex flex-col gap-4">
-        <BackLink />
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          Failed to load run: {(error as Error)?.message ?? "not found"}
-        </div>
-      </div>
-    );
-  }
-
-  const { run, phases, events, logs } = data;
 
   return (
     <div className="flex flex-col gap-6">
-      <BackLink />
-
-      <header className="flex flex-wrap items-center gap-3">
-        <h1 className="text-xl font-semibold">
-          Run #{run.id} &middot; {run.jobName}
-        </h1>
-        <StatusBadge tone={statusTone(run.status)} label={run.status} />
-        <span className="text-sm text-slate-500">
-          {formatDuration(run.startedAt, run.finishedAt)}
-        </span>
-      </header>
-
-      <section className="flex flex-col gap-2">
-        <h2 className="text-sm font-medium text-slate-500">Phases</h2>
-        <PhaseTimeline<Phase>
-          phases={phases}
-          getKey={(p) => p.id}
-          getName={(p) => p.name}
-          getTone={(p) => statusTone(p.status)}
-          getDuration={(p) => formatDuration(p.startedAt, p.finishedAt)}
-        />
-      </section>
-
-      <section className="flex flex-col gap-2">
-        <h2 className="text-sm font-medium text-slate-500">Events</h2>
-        <EventTimeline<AdminEvent>
-          items={events}
-          getKey={(e, i) => `${e.ts}-${i}`}
-          getTimestamp={(e) => e.ts}
-          getTitle={(e) => `${e.type} · ${e.phase}`}
-          getTone={(e) => statusTone(e.status)}
-        />
-      </section>
-
-      <section className="flex flex-col gap-2">
-        <h2 className="text-sm font-medium text-slate-500">Logs</h2>
-        <LogViewer logs={logs} />
-      </section>
+      <Link
+        to="/runs"
+        className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to runs
+      </Link>
+      {id === undefined ? (
+        <div className="text-sm text-red-700">Invalid run id</div>
+      ) : (
+        <RunDetailContent runId={id} />
+      )}
     </div>
-  );
-}
-
-function BackLink() {
-  return (
-    <Link
-      to="/runs"
-      className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800"
-    >
-      <ArrowLeft className="h-4 w-4" />
-      Back to runs
-    </Link>
   );
 }

--- a/go-react-admin/frontend/src/pages/RunsPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/RunsPage.test.tsx
@@ -24,3 +24,38 @@ describe("RunsPage", () => {
     });
   });
 });
+
+describe("RunsPage interactions", () => {
+  it("opens a detail drawer when a row is clicked", async () => {
+    const userEvent = (await import("@testing-library/user-event")).default;
+    const user = userEvent.setup();
+    render(<RunsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("nightly-export")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("nightly-export"));
+
+    // RunDetailContent loads inside the drawer → its section headings appear.
+    await waitFor(() => {
+      expect(screen.getByText("Phases")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Events")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("filters rows by the job name column filter", async () => {
+    const userEvent = (await import("@testing-library/user-event")).default;
+    const user = userEvent.setup();
+    render(<RunsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("cleanup")).toBeInTheDocument();
+    });
+    await user.type(screen.getByPlaceholderText("job…"), "cleanup");
+
+    expect(screen.getByText("cleanup")).toBeInTheDocument();
+    expect(screen.queryByText("nightly-export")).not.toBeInTheDocument();
+    expect(screen.queryByText("sync-users")).not.toBeInTheDocument();
+  });
+});

--- a/go-react-admin/frontend/src/pages/RunsPage.tsx
+++ b/go-react-admin/frontend/src/pages/RunsPage.tsx
@@ -1,17 +1,16 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { DataTable } from "@/components/admin/data-table";
+import { DataTable, type DataTableColumn } from "@/components/admin/data-table";
 import { Pagination } from "@/components/admin/pagination";
 import { StatusBadge } from "@/components/admin/status-badge";
-import { MetricsFilters } from "@/components/admin/metrics-filters";
+import { Drawer } from "@/components/admin/drawer";
+import { RunDetailContent } from "@/components/RunDetailContent";
 import { useRuns } from "@/hooks/useRuns";
 import { statusTone, formatDuration } from "@/lib/status";
-import type { Run, RunStatus } from "@/types/run";
+import type { Run } from "@/types/run";
 
 const PAGE_SIZE = 20;
 
 const STATUS_OPTIONS = [
-  { value: "", label: "All" },
   { value: "queued", label: "Queued" },
   { value: "running", label: "Running" },
   { value: "succeeded", label: "Succeeded" },
@@ -19,30 +18,40 @@ const STATUS_OPTIONS = [
 ];
 
 export function RunsPage() {
-  const navigate = useNavigate();
   const [page, setPage] = useState(1);
-  const [status, setStatus] = useState<RunStatus | "">("");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const { data, isLoading, isError, error } = useRuns({
-    page,
-    pageSize: PAGE_SIZE,
-    status,
-  });
+  const { data, isLoading, isError, error } = useRuns({ page, pageSize: PAGE_SIZE });
 
-  const columns = [
-    { header: "ID", cell: (row: Run) => row.id, align: "right" as const },
-    { header: "Job", cell: (row: Run) => row.jobName },
+  const columns: DataTableColumn<Run>[] = [
+    { key: "id", header: "ID", width: "5rem", align: "right", cell: (row) => row.id },
     {
-      header: "Status",
-      cell: (row: Run) => (
-        <StatusBadge tone={statusTone(row.status)} label={row.status} />
-      ),
+      key: "jobName",
+      header: "Job",
+      width: "14rem",
+      cell: (row) => row.jobName,
+      title: (row) => row.jobName,
+      filter: { kind: "text", accessor: (row) => row.jobName, placeholder: "job…" },
     },
-    { header: "Started", cell: (row: Run) => row.startedAt },
     {
+      key: "status",
+      header: "Status",
+      width: "10rem",
+      cell: (row) => <StatusBadge tone={statusTone(row.status)} label={row.status} />,
+      filter: { kind: "select", accessor: (row) => row.status, options: STATUS_OPTIONS },
+    },
+    {
+      key: "startedAt",
+      header: "Started",
+      cell: (row) => row.startedAt,
+      title: (row) => row.startedAt,
+    },
+    {
+      key: "duration",
       header: "Duration",
-      cell: (row: Run) => formatDuration(row.startedAt, row.finishedAt),
-      align: "right" as const,
+      width: "8rem",
+      align: "right",
+      cell: (row) => formatDuration(row.startedAt, row.finishedAt),
     },
   ];
 
@@ -50,20 +59,6 @@ export function RunsPage() {
     <div className="flex flex-col gap-4">
       <header className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Runs</h1>
-        <MetricsFilters
-          fields={[
-            {
-              name: "status",
-              label: "Status",
-              options: STATUS_OPTIONS,
-              value: status,
-            },
-          ]}
-          onChange={(_name, value) => {
-            setStatus(value as RunStatus | "");
-            setPage(1);
-          }}
-        />
       </header>
 
       {isError ? (
@@ -76,7 +71,7 @@ export function RunsPage() {
             columns={columns}
             rows={data?.items ?? []}
             getRowKey={(row) => row.id}
-            onRowClick={(row) => navigate(`/runs/${row.id}`)}
+            onRowClick={(row) => setSelectedId(row.id)}
             emptyMessage={isLoading ? "Loading…" : "No runs"}
           />
           <Pagination
@@ -87,6 +82,14 @@ export function RunsPage() {
           />
         </>
       )}
+
+      <Drawer
+        open={selectedId !== null}
+        onClose={() => setSelectedId(null)}
+        title={selectedId !== null ? `Run #${selectedId}` : ""}
+      >
+        {selectedId !== null && <RunDetailContent runId={selectedId} />}
+      </Drawer>
     </div>
   );
 }

--- a/shared-react-ui/src/admin/data-table.stories.tsx
+++ b/shared-react-ui/src/admin/data-table.stories.tsx
@@ -10,28 +10,61 @@ interface SampleRow {
   id: number;
   name: string;
   status: StatusTone;
+  note: string;
   duration: number;
 }
 
 const rows: SampleRow[] = [
-  { id: 1, name: "nightly-build", status: "success", duration: 42 },
-  { id: 2, name: "deploy-prod", status: "running", duration: 12 },
-  { id: 3, name: "lint-check", status: "error", duration: 5 },
+  {
+    id: 1,
+    name: "nightly-build",
+    status: "success",
+    note: "A very long note that should be clipped with an ellipsis and revealed on hover.",
+    duration: 42,
+  },
+  { id: 2, name: "deploy-prod", status: "running", note: "Deploying to production cluster", duration: 12 },
+  { id: 3, name: "lint-check", status: "error", note: "Failed: 3 lint errors", duration: 5 },
 ];
 
 const columns: DataTableColumn<SampleRow>[] = [
-  { header: "Name", cell: (r) => r.name },
-  { header: "Status", cell: (r) => <StatusBadge tone={r.status} label={r.status} /> },
-  { header: "Duration", align: "right", cell: (r) => `${r.duration}s` },
+  { key: "id", header: "ID", width: "4rem", align: "right", cell: (r) => r.id },
+  {
+    key: "name",
+    header: "Name",
+    width: "12rem",
+    cell: (r) => r.name,
+    title: (r) => r.name,
+    filter: { kind: "text", accessor: (r) => r.name, placeholder: "name…" },
+  },
+  {
+    key: "status",
+    header: "Status",
+    width: "9rem",
+    cell: (r) => <StatusBadge tone={r.status} label={r.status} />,
+    filter: {
+      kind: "select",
+      accessor: (r) => r.status,
+      options: [
+        { value: "success", label: "success" },
+        { value: "running", label: "running" },
+        { value: "error", label: "error" },
+      ],
+    },
+  },
+  // No width → flexes; truncates its long content + tooltip on hover.
+  { key: "note", header: "Note", cell: (r) => r.note, title: (r) => r.note },
+  { key: "duration", header: "Duration", width: "7rem", align: "right", cell: (r) => `${r.duration}s` },
 ];
 
 export const Default: Story = () => (
-  <DataTable
-    columns={columns}
-    rows={rows}
-    getRowKey={(r) => r.id}
-    onRowClick={(r) => console.log("clicked", r.name)}
-  />
+  <div style={{ maxWidth: 720 }}>
+    <DataTable
+      columns={columns}
+      rows={rows}
+      getRowKey={(r) => r.id}
+      onRowClick={(r) => console.log("clicked", r.name)}
+    />
+  </div>
 );
 
 export const Empty: Story = () => (

--- a/shared-react-ui/src/admin/data-table.tsx
+++ b/shared-react-ui/src/admin/data-table.tsx
@@ -2,11 +2,32 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+export type ColumnAlign = "left" | "right" | "center";
+
+export interface ColumnFilter<T> {
+  kind: "text" | "select";
+  /** Value pulled from a row for matching against the filter input. */
+  accessor: (row: T) => string;
+  /** Options for kind="select" (a leading "All" entry is added automatically). */
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
 export interface DataTableColumn<T> {
+  /** Stable id — used for the colgroup and per-column filter state. */
+  key: string;
   header: React.ReactNode;
   cell: (row: T) => React.ReactNode;
+  /** Fixed CSS width (e.g. "8rem", "20%"). Columns without one share the rest. */
+  width?: string;
+  align?: ColumnAlign;
+  /** Clip overflow with an ellipsis and reveal the full text on hover. Default true. */
+  truncate?: boolean;
+  /** Tooltip text shown on hover when the cell is truncated. */
+  title?: (row: T) => string;
+  /** Per-column filter control rendered in the filter row. */
+  filter?: ColumnFilter<T>;
   className?: string;
-  align?: "left" | "right" | "center";
 }
 
 export interface DataTableProps<T> {
@@ -18,10 +39,18 @@ export interface DataTableProps<T> {
   className?: string;
 }
 
-const alignClass: Record<NonNullable<DataTableColumn<unknown>["align"]>, string> = {
+const alignClass: Record<ColumnAlign, string> = {
   left: "text-left",
   right: "text-right",
   center: "text-center",
+};
+
+// Shared chevron-styled select (matches MetricsFilters) for select filters.
+const selectChevron: React.CSSProperties = {
+  backgroundImage:
+    "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m4 6 4 4 4-4'/%3E%3C/svg%3E\")",
+  backgroundPosition: "right 0.5rem center",
+  backgroundSize: "0.9rem",
 };
 
 export function DataTable<T>({
@@ -32,16 +61,42 @@ export function DataTable<T>({
   emptyMessage = "No data",
   className,
 }: DataTableProps<T>): React.JSX.Element {
+  const [filters, setFilters] = React.useState<Record<string, string>>({});
+  const hasFilters = columns.some((c) => c.filter);
+
+  const setFilter = (key: string, value: string) =>
+    setFilters((prev) => ({ ...prev, [key]: value }));
+
+  const visibleRows = React.useMemo(() => {
+    const active = columns.filter((c) => c.filter && (filters[c.key] ?? "") !== "");
+    if (active.length === 0) return rows;
+    return rows.filter((row) =>
+      active.every((c) => {
+        const needle = filters[c.key];
+        const hay = c.filter!.accessor(row);
+        return c.filter!.kind === "text"
+          ? hay.toLowerCase().includes(needle.toLowerCase())
+          : hay === needle;
+      })
+    );
+  }, [columns, rows, filters]);
+
   return (
-    <div className={cn("overflow-x-auto rounded-md border border-slate-200", className)}>
-      <table className="w-full border-collapse text-sm">
+    <div className={cn("overflow-hidden rounded-md border border-slate-200", className)}>
+      <table className="w-full table-fixed border-collapse text-sm">
+        <colgroup>
+          {columns.map((column) => (
+            <col key={column.key} style={column.width ? { width: column.width } : undefined} />
+          ))}
+        </colgroup>
         <thead>
           <tr className="border-b border-slate-200 bg-slate-50">
-            {columns.map((column, index) => (
+            {columns.map((column) => (
               <th
-                key={index}
+                key={column.key}
+                scope="col"
                 className={cn(
-                  "px-3 py-2 font-medium text-slate-600",
+                  "truncate px-3 py-2 font-medium text-slate-600",
                   alignClass[column.align ?? "left"],
                   column.className
                 )}
@@ -50,19 +105,31 @@ export function DataTable<T>({
               </th>
             ))}
           </tr>
+          {hasFilters && (
+            <tr className="border-b border-slate-200 bg-white">
+              {columns.map((column) => (
+                <th key={column.key} scope="col" className="px-2 py-1.5">
+                  {column.filter && (
+                    <FilterControl
+                      filter={column.filter}
+                      value={filters[column.key] ?? ""}
+                      onChange={(v) => setFilter(column.key, v)}
+                    />
+                  )}
+                </th>
+              ))}
+            </tr>
+          )}
         </thead>
         <tbody>
-          {rows.length === 0 ? (
+          {visibleRows.length === 0 ? (
             <tr>
-              <td
-                colSpan={columns.length}
-                className="px-3 py-6 text-center text-slate-400"
-              >
+              <td colSpan={columns.length} className="px-3 py-6 text-center text-slate-400">
                 {emptyMessage}
               </td>
             </tr>
           ) : (
-            rows.map((row, rowIndex) => (
+            visibleRows.map((row, rowIndex) => (
               <tr
                 key={getRowKey(row, rowIndex)}
                 onClick={onRowClick ? () => onRowClick(row) : undefined}
@@ -71,23 +138,68 @@ export function DataTable<T>({
                   onRowClick && "cursor-pointer hover:bg-slate-50"
                 )}
               >
-                {columns.map((column, colIndex) => (
-                  <td
-                    key={colIndex}
-                    className={cn(
-                      "px-3 py-2 text-slate-700",
-                      alignClass[column.align ?? "left"],
-                      column.className
-                    )}
-                  >
-                    {column.cell(row)}
-                  </td>
-                ))}
+                {columns.map((column) => {
+                  const truncate = column.truncate !== false;
+                  return (
+                    <td
+                      key={column.key}
+                      className={cn(
+                        "px-3 py-2 align-middle text-slate-700",
+                        alignClass[column.align ?? "left"],
+                        column.className
+                      )}
+                    >
+                      <div
+                        className={cn(truncate && "truncate")}
+                        title={truncate ? column.title?.(row) : undefined}
+                      >
+                        {column.cell(row)}
+                      </div>
+                    </td>
+                  );
+                })}
               </tr>
             ))
           )}
         </tbody>
       </table>
     </div>
+  );
+}
+
+function FilterControl<T>({
+  filter,
+  value,
+  onChange,
+}: {
+  filter: ColumnFilter<T>;
+  value: string;
+  onChange: (value: string) => void;
+}): React.JSX.Element {
+  if (filter.kind === "select") {
+    return (
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-full appearance-none rounded-md border border-slate-300 bg-white bg-no-repeat py-0 pl-2 pr-7 text-xs font-normal text-slate-700 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-400"
+        style={selectChevron}
+      >
+        <option value="">{filter.placeholder ?? "All"}</option>
+        {filter.options?.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={filter.placeholder ?? "Filter…"}
+      className="h-8 w-full rounded-md border border-slate-300 bg-white px-2 text-xs font-normal text-slate-700 placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-400"
+    />
   );
 }

--- a/shared-react-ui/src/admin/drawer.stories.tsx
+++ b/shared-react-ui/src/admin/drawer.stories.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import type { Story } from "@ladle/react";
+import { Drawer } from "./drawer";
+
+export default {
+  title: "Admin / Drawer",
+};
+
+export const Default: Story = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white"
+      >
+        Open drawer
+      </button>
+      <p className="mt-4 text-sm text-slate-500">
+        The page stays visible behind the dimmed backdrop. Click the backdrop or press Escape to close.
+      </p>
+      <Drawer open={open} onClose={() => setOpen(false)} title="Run #1234">
+        <div className="space-y-3 text-sm text-slate-700">
+          <p>Half-overlay detail panel (NewRelic style).</p>
+          <p>Put any detail content here — summaries, timelines, logs, etc.</p>
+        </div>
+      </Drawer>
+    </div>
+  );
+};

--- a/shared-react-ui/src/admin/drawer.tsx
+++ b/shared-react-ui/src/admin/drawer.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// Inline close (×) icon — keeps shared-react-ui free of an icon dependency.
+function CloseIcon(): React.JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  children: React.ReactNode;
+  /** Override the panel width. Defaults to a ~half-screen overlay. */
+  widthClassName?: string;
+}
+
+/**
+ * Drawer is a NewRelic-style half-overlay: a right-aligned panel slides in over
+ * the content, with the page dimmed (but still visible) behind a backdrop.
+ * Closes on backdrop click or Escape.
+ */
+export function Drawer({
+  open,
+  onClose,
+  title,
+  children,
+  widthClassName = "w-full sm:w-[560px] lg:w-[44rem] max-w-[90vw]",
+}: DrawerProps): React.JSX.Element | null {
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-40">
+      {/* Backdrop: dims the page but keeps it visible; click closes. */}
+      <div
+        className="absolute inset-0 bg-black/30"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          "absolute right-0 top-0 flex h-full flex-col border-l border-slate-200 bg-white shadow-xl",
+          "animate-in slide-in-from-right duration-200",
+          widthClassName
+        )}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-slate-200 px-5 py-3">
+          <div className="min-w-0 truncate text-base font-semibold text-slate-800">{title}</div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/shared-react-ui/src/admin/index.ts
+++ b/shared-react-ui/src/admin/index.ts
@@ -25,7 +25,15 @@ export { PhaseTimeline } from "./phase-timeline";
 export type { PhaseTimelineProps } from "./phase-timeline";
 
 export { DataTable } from "./data-table";
-export type { DataTableColumn, DataTableProps } from "./data-table";
+export type {
+  ColumnAlign,
+  ColumnFilter,
+  DataTableColumn,
+  DataTableProps,
+} from "./data-table";
+
+export { Drawer } from "./drawer";
+export type { DrawerProps } from "./drawer";
 
 export { StackedBarChart } from "./stacked-bar-chart";
 export type { StackedBarSeries, StackedBarChartProps } from "./stacked-bar-chart";


### PR DESCRIPTION
## 概要

要望 5 点に対応する（親 #246 / #264）。

1. テーブルに**列フィルタ**（text/select）。
2. **テーブル幅固定・カラム幅が内容でブレない**（`table-fixed` + `colgroup`）。
3. **長い値は省略（…）+ ホバーで全体表示**（`truncate` + `title`）。
4. **テーブル設定を共通化**（列定義に width/truncate/filter を内包）。
5. テーブル→詳細を **NewRelic 風の半オーバーレイ（右スライドのドロワー）** に。

## 関連 Issue

Closes: #264
Refs: #246

## 変更

### shared-react-ui
- `DataTable<T>` 再設計: `DataTableColumn` に `key/width/align/truncate/title/filter`。`table-fixed`+`colgroup` で列幅固定、truncate 列は省略+tooltip、`filter` があればフィルタ行を自動表示しクライアント側で絞り込み。
- `Drawer`（新規）: 右スライド半オーバーレイ。背景クリック / Esc で閉じる。lucide 非依存（インライン X）。
- stories 更新（固定幅/省略/フィルタ、Drawer）。

### go-react-admin
- `RunDetailContent` / `JobDetailContent` を抽出し、**ドロワー**と**直 URL ページ**（`/runs/:id`, `/jobs/:id`）の両方で再利用。
- Runs/Jobs 一覧を新列 API に移行。**行クリックでドロワー詳細**（遷移廃止）。列フィルタ: Runs=status(select)+job名(text)、Jobs=kind(text)+enabled(select)。
- Job ドロワーに Edit/Delete、履歴の run 行は run 詳細ページへ遷移（ドロワー入れ子回避）。
- テスト更新 + ドロワー/フィルタテスト追加。

## テスト

- [x] shared-ui: `tsc --noEmit` / `gallery:build` 緑
- [x] frontend: tsc / eslint / prettier / **vitest 36** / build 緑

## チェックリスト

- [x] `Closes:` #264 / 親 #246 は `Refs:`
- [x] 機密情報なし / Conventional Commits / base=main

## 補足 / レビュー観点

- フィルタはクライアント側（提供行を絞り込み）。Jobs は全件ロードのため完全に機能。**Runs はサーバページングのため現在ページ内の絞り込み**になる（デモ用途では許容。従来のサーバ side status フィルタは列 select フィルタに置換）。
- 直 URL ページは content コンポーネント再利用で deep link を維持。
- `DataTable`/`Drawer` は shared-react-ui の共有資産。修正はソースに入れ、frontend へは compose 反映（composed コピーは gitignore）。