### PR TITLE
feat(go-react-admin): Config に Time zone 設定を追加（既定 JST）し表示に反映

### DIFF
--- a/go-react-admin/frontend/src/components/JobDetailContent.tsx
+++ b/go-react-admin/frontend/src/components/JobDetailContent.tsx
@@ -6,7 +6,9 @@ import { StatusBadge } from "@/components/admin/status-badge";
 import { Button } from "@/components/ui/button";
 import { useJob, useDeleteJob } from "@/hooks/useJobs";
 import { useRuns } from "@/hooks/useRuns";
+import { useTimeZone } from "@/hooks/useConfig";
 import { statusTone, formatDuration } from "@/lib/status";
+import { formatInstant } from "@/lib/datetime";
 import type { JobView } from "@/types/job";
 import type { Run } from "@/types/run";
 
@@ -51,6 +53,7 @@ function JobBody({
 }) {
   const navigate = useNavigate();
   const deleteJob = useDeleteJob();
+  const tz = useTimeZone();
   const [page, setPage] = useState(1);
 
   const { data: runs, isLoading: runsLoading } = useRuns({
@@ -75,8 +78,8 @@ function JobBody({
     {
       key: "startedAt",
       header: "Started",
-      cell: (row) => row.startedAt,
-      title: (row) => row.startedAt,
+      cell: (row) => formatInstant(row.startedAt, tz),
+      title: (row) => formatInstant(row.startedAt, tz),
     },
     {
       key: "duration",
@@ -118,9 +121,9 @@ function JobBody({
         <Field label="Kind" value={job.kind} />
         <Field label="Schedule" value={job.schedule} mono />
         <Field label="Runs" value={String(job.runCount)} />
-        <Field label="Last run" value={job.lastRunAt ?? "—"} />
-        <Field label="Next run" value={job.nextRunAt ?? "—"} />
-        <Field label="Created" value={job.createdAt} />
+        <Field label="Last run" value={formatInstant(job.lastRunAt, tz)} />
+        <Field label="Next run" value={formatInstant(job.nextRunAt, tz)} />
+        <Field label="Created" value={formatInstant(job.createdAt, tz)} />
       </dl>
 
       <section className="flex flex-col gap-3">

--- a/go-react-admin/frontend/src/components/LogViewer.tsx
+++ b/go-react-admin/frontend/src/components/LogViewer.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { formatInstant } from "@/lib/datetime";
 import type { LogLine } from "@/types/run";
 
 const LEVEL_COLORS: Record<string, string> = {
@@ -17,9 +18,16 @@ export interface LogViewerProps {
   logs: LogLine[];
   emptyMessage?: string;
   className?: string;
+  /** IANA time zone for formatting log timestamps. */
+  timeZone?: string;
 }
 
-export function LogViewer({ logs, emptyMessage = "No logs", className }: LogViewerProps) {
+export function LogViewer({
+  logs,
+  emptyMessage = "No logs",
+  className,
+  timeZone,
+}: LogViewerProps) {
   if (logs.length === 0) {
     return (
       <div className="rounded-md border border-slate-200 bg-white px-3 py-6 text-center text-sm text-slate-400">
@@ -37,7 +45,9 @@ export function LogViewer({ logs, emptyMessage = "No logs", className }: LogView
     >
       {logs.map((log, index) => (
         <div key={index} className="flex gap-2 whitespace-pre-wrap py-0.5">
-          <span className="shrink-0 text-slate-500">{log.ts}</span>
+          <span className="shrink-0 text-slate-500">
+            {formatInstant(log.ts, timeZone)}
+          </span>
           <span className={cn("shrink-0 uppercase", levelColor(log.level))}>
             {log.level}
           </span>

--- a/go-react-admin/frontend/src/components/RunDetailContent.tsx
+++ b/go-react-admin/frontend/src/components/RunDetailContent.tsx
@@ -3,7 +3,9 @@ import { PhaseTimeline } from "@/components/admin/phase-timeline";
 import { EventTimeline } from "@/components/admin/event-timeline";
 import { LogViewer } from "@/components/LogViewer";
 import { useRun } from "@/hooks/useRuns";
+import { useTimeZone } from "@/hooks/useConfig";
 import { statusTone, formatDuration } from "@/lib/status";
+import { formatInstant } from "@/lib/datetime";
 import type { AdminEvent, Phase } from "@/types/run";
 
 // RunDetailContent renders a run's detail (summary + timelines + logs). It is
@@ -11,6 +13,7 @@ import type { AdminEvent, Phase } from "@/types/run";
 // full-page route /runs/:id, so it owns no page chrome (no back link).
 export function RunDetailContent({ runId }: { runId: number }) {
   const { data, isLoading, isError, error } = useRun(runId);
+  const tz = useTimeZone();
 
   if (isLoading) {
     return <div className="text-sm text-slate-500">Loading…</div>;
@@ -53,7 +56,7 @@ export function RunDetailContent({ runId }: { runId: number }) {
         <EventTimeline<AdminEvent>
           items={events}
           getKey={(e, i) => `${e.ts}-${i}`}
-          getTimestamp={(e) => e.ts}
+          getTimestamp={(e) => formatInstant(e.ts, tz)}
           getTitle={(e) => `${e.type} · ${e.phase}`}
           getTone={(e) => statusTone(e.status)}
         />
@@ -61,7 +64,7 @@ export function RunDetailContent({ runId }: { runId: number }) {
 
       <section className="flex flex-col gap-2">
         <h3 className="text-sm font-medium text-slate-500">Logs</h3>
-        <LogViewer logs={logs} />
+        <LogViewer logs={logs} timeZone={tz} />
       </section>
     </div>
   );

--- a/go-react-admin/frontend/src/hooks/useConfig.ts
+++ b/go-react-admin/frontend/src/hooks/useConfig.ts
@@ -9,6 +9,13 @@ export function useConfig() {
   });
 }
 
+// useTimeZone returns the configured display time zone (Config → time_zone),
+// defaulting to Asia/Tokyo (JST) before config loads or if unset.
+export function useTimeZone(): string {
+  const { data } = useConfig();
+  return data?.items.find((i) => i.key === "time_zone")?.value || "Asia/Tokyo";
+}
+
 // useUpdateConfig persists edited toml settings (applied on restart).
 export function useUpdateConfig() {
   const queryClient = useQueryClient();

--- a/go-react-admin/frontend/src/lib/datetime.test.ts
+++ b/go-react-admin/frontend/src/lib/datetime.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { formatInstant } from "./datetime";
+
+describe("formatInstant", () => {
+  it("formats an instant in the given time zone", () => {
+    // 2026-06-17T00:00:00Z is 09:00 in Tokyo (UTC+9).
+    const jst = formatInstant("2026-06-17T00:00:00Z", "Asia/Tokyo");
+    expect(jst).toContain("2026-06-17");
+    expect(jst).toContain("09:00:00");
+    // ...and 20:00 the previous day in New York (UTC-4 in June).
+    const ny = formatInstant("2026-06-17T00:00:00Z", "America/New_York");
+    expect(ny).toContain("2026-06-16");
+    expect(ny).toContain("20:00:00");
+  });
+
+  it("returns an em dash for nullish input", () => {
+    expect(formatInstant(null, "Asia/Tokyo")).toBe("—");
+    expect(formatInstant(undefined, "Asia/Tokyo")).toBe("—");
+  });
+
+  it("defaults to Asia/Tokyo when no zone is given", () => {
+    expect(formatInstant("2026-06-17T00:00:00Z")).toContain("09:00:00");
+  });
+});

--- a/go-react-admin/frontend/src/lib/datetime.ts
+++ b/go-react-admin/frontend/src/lib/datetime.ts
@@ -1,0 +1,31 @@
+// Timestamp formatting honoring the configured time zone (Config → time_zone,
+// default Asia/Tokyo). Durations are time-zone independent and stay in status.ts.
+
+const DEFAULT_TIME_ZONE = "Asia/Tokyo";
+
+// formatInstant renders an absolute ISO timestamp in the given IANA time zone,
+// e.g. "2026-06-17 12:32:00". Falls back gracefully on bad input/zone.
+export function formatInstant(
+  iso: string | null | undefined,
+  timeZone: string = DEFAULT_TIME_ZONE
+): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return String(iso);
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+      timeZone,
+    }).format(date);
+    // en-CA yields "2026-06-17, 12:32:00" → drop the comma for compactness.
+    return parts.replace(",", "");
+  } catch {
+    return date.toISOString();
+  }
+}

--- a/go-react-admin/frontend/src/pages/ConfigPage.test.tsx
+++ b/go-react-admin/frontend/src/pages/ConfigPage.test.tsx
@@ -36,3 +36,11 @@ describe("ConfigPage", () => {
     });
   });
 });
+
+describe("ConfigPage time zone", () => {
+  it("shows Time zone as an editable field seeded from config", async () => {
+    render(<ConfigPage />);
+    const input = await screen.findByDisplayValue("Asia/Tokyo");
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/go-react-admin/frontend/src/pages/ConfigPage.tsx
+++ b/go-react-admin/frontend/src/pages/ConfigPage.tsx
@@ -41,6 +41,7 @@ export function ConfigPage() {
     const input: UpdateConfigInput = {
       worker_interval: edits["worker_interval"],
       shutdown_timeout: edits["shutdown_timeout"],
+      time_zone: edits["time_zone"],
     };
     updateConfig.mutate(input, {
       onSuccess: () => {

--- a/go-react-admin/frontend/src/pages/JobsPage.tsx
+++ b/go-react-admin/frontend/src/pages/JobsPage.tsx
@@ -8,6 +8,8 @@ import { Drawer } from "@/components/admin/drawer";
 import { Button } from "@/components/ui/button";
 import { JobDetailContent } from "@/components/JobDetailContent";
 import { useJobs } from "@/hooks/useJobs";
+import { useTimeZone } from "@/hooks/useConfig";
+import { formatInstant } from "@/lib/datetime";
 import type { JobView } from "@/types/job";
 
 const ENABLED_OPTIONS = [
@@ -19,6 +21,7 @@ export function JobsPage() {
   const navigate = useNavigate();
   const { data, isLoading, isError, error } = useJobs();
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const tz = useTimeZone();
 
   const columns: DataTableColumn<JobView>[] = [
     {
@@ -62,14 +65,14 @@ export function JobsPage() {
     {
       key: "lastRunAt",
       header: "Last run",
-      cell: (row) => row.lastRunAt ?? "—",
-      title: (row) => row.lastRunAt ?? "",
+      cell: (row) => formatInstant(row.lastRunAt, tz),
+      title: (row) => formatInstant(row.lastRunAt, tz),
     },
     {
       key: "nextRunAt",
       header: "Next run",
-      cell: (row) => row.nextRunAt ?? "—",
-      title: (row) => row.nextRunAt ?? "",
+      cell: (row) => formatInstant(row.nextRunAt, tz),
+      title: (row) => formatInstant(row.nextRunAt, tz),
     },
     {
       key: "runCount",

--- a/go-react-admin/frontend/src/pages/RunsPage.tsx
+++ b/go-react-admin/frontend/src/pages/RunsPage.tsx
@@ -5,7 +5,9 @@ import { StatusBadge } from "@/components/admin/status-badge";
 import { Drawer } from "@/components/admin/drawer";
 import { RunDetailContent } from "@/components/RunDetailContent";
 import { useRuns } from "@/hooks/useRuns";
+import { useTimeZone } from "@/hooks/useConfig";
 import { statusTone, formatDuration } from "@/lib/status";
+import { formatInstant } from "@/lib/datetime";
 import type { Run } from "@/types/run";
 
 const PAGE_SIZE = 20;
@@ -20,6 +22,7 @@ const STATUS_OPTIONS = [
 export function RunsPage() {
   const [page, setPage] = useState(1);
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const tz = useTimeZone();
 
   const { data, isLoading, isError, error } = useRuns({ page, pageSize: PAGE_SIZE });
 
@@ -43,8 +46,8 @@ export function RunsPage() {
     {
       key: "startedAt",
       header: "Started",
-      cell: (row) => row.startedAt,
-      title: (row) => row.startedAt,
+      cell: (row) => formatInstant(row.startedAt, tz),
+      title: (row) => formatInstant(row.startedAt, tz),
     },
     {
       key: "duration",

--- a/go-react-admin/frontend/src/test/mocks/handlers.ts
+++ b/go-react-admin/frontend/src/test/mocks/handlers.ts
@@ -173,6 +173,13 @@ export const mockConfig: ConfigResponse = {
       source: "toml",
       editable: true,
     },
+    {
+      key: "time_zone",
+      label: "Time zone",
+      value: "Asia/Tokyo",
+      source: "toml",
+      editable: true,
+    },
   ],
 };
 

--- a/go-react-admin/frontend/src/types/run.ts
+++ b/go-react-admin/frontend/src/types/run.ts
@@ -32,4 +32,5 @@ export type UpdateConfigResponse = z.infer<typeof updateConfigResponseSchema>;
 export interface UpdateConfigInput {
   worker_interval?: string;
   shutdown_timeout?: string;
+  time_zone?: string;
 }

--- a/go-react-admin/internal/config/config.go
+++ b/go-react-admin/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	_ "time/tzdata" // embed the IANA tz database so LoadLocation works anywhere
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/sethvargo/go-envconfig"
@@ -34,6 +35,7 @@ type envConfig struct {
 type FileConfig struct {
 	WorkerInterval  string `toml:"worker_interval"`
 	ShutdownTimeout string `toml:"shutdown_timeout"`
+	TimeZone        string `toml:"time_zone"`
 }
 
 // Defaults for the file-backed settings, used when the toml file or a key is
@@ -41,17 +43,16 @@ type FileConfig struct {
 const (
 	defaultWorkerInterval  = "15s"
 	defaultShutdownTimeout = "10s"
+	defaultTimeZone        = "Asia/Tokyo" // JST
 )
 
 // Config is the fully resolved runtime configuration.
 type Config struct {
-	// env-sourced (read-only)
-	Port        string `json:"port"`
-	DatabaseDSN string `json:"database_dsn"`
-	LogDir      string `json:"log_dir"`
-	ConfigFile  string `json:"config_file"`
-
-	// file-sourced (editable), resolved to durations
+	Port            string        `json:"port"`
+	DatabaseDSN     string        `json:"database_dsn"`
+	LogDir          string        `json:"log_dir"`
+	ConfigFile      string        `json:"config_file"`
+	TimeZone        string        `json:"time_zone"`
 	WorkerInterval  time.Duration `json:"worker_interval"`
 	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
 }
@@ -78,6 +79,9 @@ func Load(ctx context.Context) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("config %s: shutdown_timeout %q: %w", ec.ConfigFile, fc.ShutdownTimeout, err)
 	}
+	if _, err := time.LoadLocation(fc.TimeZone); err != nil {
+		return Config{}, fmt.Errorf("config %s: time_zone %q: %w", ec.ConfigFile, fc.TimeZone, err)
+	}
 
 	return Config{
 		Port:            ec.Port,
@@ -86,13 +90,18 @@ func Load(ctx context.Context) (Config, error) {
 		ConfigFile:      ec.ConfigFile,
 		WorkerInterval:  workerInterval,
 		ShutdownTimeout: shutdownTimeout,
+		TimeZone:        fc.TimeZone,
 	}, nil
 }
 
 // ReadFile reads the toml file, falling back to defaults for a missing file or
 // any unset key. The returned FileConfig always has both fields populated.
 func ReadFile(path string) (FileConfig, error) {
-	fc := FileConfig{WorkerInterval: defaultWorkerInterval, ShutdownTimeout: defaultShutdownTimeout}
+	fc := FileConfig{
+		WorkerInterval:  defaultWorkerInterval,
+		ShutdownTimeout: defaultShutdownTimeout,
+		TimeZone:        defaultTimeZone,
+	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -112,6 +121,9 @@ func ReadFile(path string) (FileConfig, error) {
 	if parsed.ShutdownTimeout != "" {
 		fc.ShutdownTimeout = parsed.ShutdownTimeout
 	}
+	if parsed.TimeZone != "" {
+		fc.TimeZone = parsed.TimeZone
+	}
 	return fc, nil
 }
 
@@ -123,6 +135,9 @@ func WriteFile(path string, fc FileConfig) error {
 	}
 	if _, err := time.ParseDuration(fc.ShutdownTimeout); err != nil {
 		return fmt.Errorf("shutdown_timeout %q: %w", fc.ShutdownTimeout, err)
+	}
+	if _, err := time.LoadLocation(fc.TimeZone); err != nil {
+		return fmt.Errorf("time_zone %q: %w", fc.TimeZone, err)
 	}
 
 	data, err := toml.Marshal(fc)

--- a/go-react-admin/internal/config/config_test.go
+++ b/go-react-admin/internal/config/config_test.go
@@ -135,3 +135,33 @@ func TestEnsureFile_CreatesWhenAbsent(t *testing.T) {
 		t.Errorf("EnsureFile overwrote existing file: %+v", fc)
 	}
 }
+
+func TestLoad_DefaultTimeZoneIsJST(t *testing.T) {
+	t.Setenv("CONFIG_FILE", filepath.Join(t.TempDir(), "absent.toml"))
+	cfg, err := Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.TimeZone != "Asia/Tokyo" {
+		t.Errorf("TimeZone = %q, want Asia/Tokyo (JST default)", cfg.TimeZone)
+	}
+}
+
+func TestLoad_InvalidTimeZoneReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(`time_zone = "Mars/Phobos"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CONFIG_FILE", path)
+	if _, err := Load(context.Background()); err == nil {
+		t.Error("Load with invalid time_zone = nil, want error")
+	}
+}
+
+func TestWriteFile_RejectsInvalidTimeZone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	err := WriteFile(path, FileConfig{WorkerInterval: "15s", ShutdownTimeout: "10s", TimeZone: "Nope/Nope"})
+	if err == nil {
+		t.Error("WriteFile with invalid time_zone = nil, want error")
+	}
+}

--- a/go-react-admin/internal/server/server.go
+++ b/go-react-admin/internal/server/server.go
@@ -54,6 +54,7 @@ func Run(ctx context.Context) error {
 	if ferr := config.EnsureFile(cfg.ConfigFile, config.FileConfig{
 		WorkerInterval:  cfg.WorkerInterval.String(),
 		ShutdownTimeout: cfg.ShutdownTimeout.String(),
+		TimeZone:        cfg.TimeZone,
 	}); ferr != nil {
 		slog.Warn("could not materialize config file", "path", cfg.ConfigFile, "error", ferr)
 	}

--- a/go-react-admin/internal/web/web.go
+++ b/go-react-admin/internal/web/web.go
@@ -399,6 +399,7 @@ func (s *Server) getConfig(c *gin.Context) {
 			{Key: "log_dir", Label: "Log directory", Value: cfg.LogDir, Source: "env", Editable: false},
 			{Key: "worker_interval", Label: "Worker interval", Value: cfg.WorkerInterval.String(), Source: "toml", Editable: true},
 			{Key: "shutdown_timeout", Label: "Shutdown timeout", Value: cfg.ShutdownTimeout.String(), Source: "toml", Editable: true},
+			{Key: "time_zone", Label: "Time zone", Value: cfg.TimeZone, Source: "toml", Editable: true},
 		},
 	})
 }
@@ -406,6 +407,7 @@ func (s *Server) getConfig(c *gin.Context) {
 type updateConfigRequest struct {
 	WorkerInterval  string `json:"worker_interval"`
 	ShutdownTimeout string `json:"shutdown_timeout"`
+	TimeZone        string `json:"time_zone"`
 }
 
 // updateConfig persists the editable (toml) settings. Env settings are not
@@ -430,6 +432,9 @@ func (s *Server) updateConfig(c *gin.Context) {
 	if req.ShutdownTimeout != "" {
 		current.ShutdownTimeout = req.ShutdownTimeout
 	}
+	if req.TimeZone != "" {
+		current.TimeZone = req.TimeZone
+	}
 
 	if err := config.WriteFile(s.deps.Config.ConfigFile, current); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -439,6 +444,7 @@ func (s *Server) updateConfig(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"workerInterval":  current.WorkerInterval,
 		"shutdownTimeout": current.ShutdownTimeout,
+		"timeZone":        current.TimeZone,
 		"restartRequired": true,
 	})
 }

--- a/go-react-admin/internal/web/web_test.go
+++ b/go-react-admin/internal/web/web_test.go
@@ -206,9 +206,9 @@ func newConfigServer(t *testing.T) (http.Handler, string, *bool) {
 	return h, cfgPath, &restarted
 }
 
-func putJSON(h http.Handler, target, body string) *httptest.ResponseRecorder {
+func putJSON(h http.Handler, body string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, target, strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(rec, req)
 	return rec
@@ -216,7 +216,7 @@ func putJSON(h http.Handler, target, body string) *httptest.ResponseRecorder {
 
 func TestUpdateConfig_WritesTomlFile(t *testing.T) {
 	h, cfgPath, _ := newConfigServer(t)
-	rec := putJSON(h, "/api/config", `{"worker_interval":"20s","shutdown_timeout":"25s"}`)
+	rec := putJSON(h, `{"worker_interval":"20s","shutdown_timeout":"25s"}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -231,7 +231,7 @@ func TestUpdateConfig_WritesTomlFile(t *testing.T) {
 
 func TestUpdateConfig_RejectsInvalidDuration(t *testing.T) {
 	h, _, _ := newConfigServer(t)
-	rec := putJSON(h, "/api/config", `{"worker_interval":"banana"}`)
+	rec := putJSON(h, `{"worker_interval":"banana"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
@@ -420,5 +420,48 @@ func TestQueryParamFallbacks(t *testing.T) {
 	// garbage from/to fall back to defaults (parseTimeDefault error branch)
 	if rec := do(h, "/api/metrics/aggregate?from=nope&to=nope"); rec.Code != http.StatusOK {
 		t.Errorf("garbage range status = %d, want 200 (fallback)", rec.Code)
+	}
+}
+
+func TestConfig_IncludesEditableTimeZone(t *testing.T) {
+	h, _ := newTestServer(t)
+	rec := do(h, "/api/config")
+	var resp configResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found *configItem
+	for i := range resp.Items {
+		if resp.Items[i].Key == "time_zone" {
+			found = &resp.Items[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("time_zone item missing from /api/config")
+	}
+	if found.Source != "toml" || !found.Editable {
+		t.Errorf("time_zone should be toml/editable: %+v", *found)
+	}
+}
+
+func TestUpdateConfig_PersistsTimeZone(t *testing.T) {
+	h, cfgPath, _ := newConfigServer(t)
+	rec := putJSON(h, `{"time_zone":"America/New_York"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	fc, err := config.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if fc.TimeZone != "America/New_York" {
+		t.Errorf("time_zone not persisted: %+v", fc)
+	}
+}
+
+func TestUpdateConfig_RejectsInvalidTimeZone(t *testing.T) {
+	h, _, _ := newConfigServer(t)
+	if rec := putJSON(h, `{"time_zone":"Nope/Nope"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }


### PR DESCRIPTION
## 概要
Config で **Time zone** を指定できるようにする。**既定は JST（Asia/Tokyo）**。設定した tz で一覧/詳細の絶対時刻表示を整形する。

## 関連 Issue
Closes: #266
Refs: #246

## 変更
### backend
- `internal/config`: 編集可能 toml 層に `time_zone`（既定 `Asia/Tokyo`）。`Load`/`WriteFile` で `time.LoadLocation` によりバリデーション。`time/tzdata` を埋め込み（最小環境でも解決可）。
- `internal/web`: `GET /api/config` items に `time_zone`（toml/editable）、`PUT /api/config` が受理。Config 画面は editable 項目を汎用描画するため**自動でフォーム表示**（保存→Restart で反映）。

### frontend
- `lib/datetime.formatInstant(iso, tz)` + `useTimeZone()`（config 由来・既定 JST）。
- 絶対時刻表示を tz 整形: Runs(started) / Jobs(last,next) / Job 詳細(各日時+履歴) / Run 詳細(イベント時刻) / LogViewer(ログ時刻)。期間は tz 非依存で対象外。

## 動作確認（実バイナリ）
- 既定 `Asia/Tokyo`、`GET /api/config` に `time_zone`(toml/editable)
- 不正 tz（`Mars/Phobos`）→ **400**
- `PUT time_zone=America/New_York` → `restart` → 反映を確認、JST に戻して確認

## テスト
- [x] go test **80.7%** / golangci-lint **0** / vitest **40** / eslint / prettier / build 緑（`formatInstant` の tz 変換ユニットテスト含む）

## チェックリスト
- [x] `Closes:` #266 / 親 #246 は `Refs:` / 機密情報なし / Conventional Commits / base=main / schema 変更なし（toml のみ）