### PR TITLE
fix(go-react-admin): embed 用 dist/ プレースホルダを確保し lint/test を修正

### DIFF
--- a/boilerplates/go-react-admin/Makefile
+++ b/boilerplates/go-react-admin/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build build-frontend compose-ui run run-binary run-server run-frontend stop status \
+.PHONY: install build build-frontend compose-ui embed-dist run run-binary run-server run-frontend stop status \
   lint lint-frontend lint-fix format format-check \
   test test-frontend test-cov test-watch coverage \
   check ci clean help
@@ -81,8 +81,16 @@ status:
 	@lsof -i :$(PORT) >/dev/null 2>&1 && echo "go-react-admin (Go): running (:$(PORT))" || echo "go-react-admin (Go): stopped"
 	@lsof -i :$(FRONTEND_PORT) >/dev/null 2>&1 && echo "go-react-admin (Vite): running (:$(FRONTEND_PORT))" || echo "go-react-admin (Vite): stopped"
 
+## embed-dist: Ensure internal/static/dist/ exists so the //go:embed all:dist
+## typecheck in static_embed.go resolves before `make build-frontend`. Fresh
+## checkouts (dist/* is gitignored) and scaffolded projects (dist/ is stripped
+## as a build artifact) have no dist/ yet, which would otherwise fail any Go
+## compile under the default !dev build tag.
+embed-dist:
+	@mkdir -p internal/static/dist && touch internal/static/dist/.gitkeep
+
 ## lint: Run golangci-lint
-lint:
+lint: embed-dist
 	golangci-lint run
 
 ## lint-frontend: Run the frontend linter
@@ -102,7 +110,7 @@ format-check: compose-ui
 	@if [ -d $(FRONTEND_DIR) ]; then cd $(FRONTEND_DIR) && npm run format:check; else echo "no frontend/ yet"; fi
 
 ## test: Run Go tests
-test:
+test: embed-dist
 	go test $(GO_PKGS)
 
 ## test-frontend: Run frontend tests
@@ -110,7 +118,7 @@ test-frontend: compose-ui
 	@if [ -d $(FRONTEND_DIR) ]; then cd $(FRONTEND_DIR) && npm run test; else echo "no frontend/ yet"; fi
 
 ## test-cov: Run Go tests with coverage
-test-cov:
+test-cov: embed-dist
 	go test -coverprofile=$(COVERAGE_FILE) $(GO_PKGS)
 	go tool cover -func=$(COVERAGE_FILE) | tail -1
 


### PR DESCRIPTION
## 概要

`go-react-admin` の `go-react-admin CI` と `Scaffold Verify go-react-admin` が `main` で恒常的に赤だった問題を修正する。`make ci`（先頭の `lint` → `golangci-lint`）が `internal/static/static_embed.go` の `//go:embed all:dist` を解決できず、`pattern all:dist: no matching files found (typecheck)` で失敗していた。`dist/*` は gitignore され、scaffold 時は `dist/` が成果物として除去されるため、`build-frontend` を通らない `lint`/`test` 系で embed 対象が存在しなかったのが根本原因。

## 関連 Issue

Refs: #229

## Affects

なし

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: 挙動変更なしのリファクタ
- [ ] perf: パフォーマンス改善
- [ ] chore / docs / test
- [ ] schema: DB スキーマ変更あり

## 動作確認手順（ローカル起動）

```bash
cd boilerplates/go-react-admin
rm -rf internal/static/dist      # fresh checkout / scaffold 直後を再現
make embed-dist                  # dist/.gitkeep を生成
go build ./...                   # //go:embed all:dist が解決 => BUILD OK
go test ./internal/static/...    # ok
```

### 動作確認シナリオ

- [x] `dist/` を削除した状態から `make embed-dist` → `go build ./...` が成功
- [x] `go test ./internal/static/...` が PASS（テストは `fstest.MapFS` を使用し実アセット不要）

## テスト

- [x] `make ci` 相当（lint→test）の typecheck が通ることを `go build`/`go test` で確認
- [ ] 新規/変更コードに対するユニットテストを追加した（N/A: Makefile 配線の修正）

## チェックリスト

- [x] `Refs:` / `Closes:` の使い分けが正しい（#229 は close 済みのため `Refs:`）
- [x] README の更新が必要なら反映した（N/A）
- [x] 機密情報（API キー等）を含まない
- [x] PR タイトルが Conventional Commits 形式
- [x] base ブランチが `main`

## 補足 / レビュー観点

- 修正は2点:
  1. `embed-dist` ターゲットを追加し `lint` / `test` / `test-cov` の前提にして、`golangci-lint` / `go test` 実行前に `internal/static/dist/.gitkeep` を必ず用意する（per-template CI と scaffold-verify の両経路をカバー）。
  2. `.gitignore` が既に `!dist/.gitkeep` で許可していた `dist/.gitkeep` を実際にコミット（これまで未追跡だった）。make を介さない `go build ./...` も fresh checkout で通る。
- #229（boilerplates/ 集約）とは独立した既存不具合の修正。`main` 上でも #263/#265/#267 時点から同じエラーで赤だった。
