### PR TITLE
feat(go templates): make setup を追加し air/golangci-lint を一括導入 (#245)

### DIFF
--- a/boilerplates/go-graphql-api/Makefile
+++ b/boilerplates/go-graphql-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run run-bare stop status lint test test-cov check ci generate migrate migrate-diff migrate-apply migrate-hash clean help
+.PHONY: install setup build run run-bare stop status lint test test-cov check ci generate migrate migrate-diff migrate-apply migrate-hash clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -8,17 +8,26 @@ BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 8080
+# golangci-lint version installed by `make setup`. Keep in sync with CI
+# (.github/workflows/go-ci.yml).
+GOLANGCI_VERSION := v2.11.2
 
-## install: Download dependencies and dev tools
+## install: Download dependencies (go modules only)
 install:
 	go mod download
+
+## setup: Bootstrap dev env — deps (install) + dev tools (air, golangci-lint)
+setup: install
 	go install github.com/air-verse/air@latest
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b "$$(go env GOPATH)/bin" $(GOLANGCI_VERSION)
 
 ## build: Build the binary
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server with hot reload (requires air; installed by `make install`)
+## run: Run the server with hot reload (requires air; installed by `make setup`)
 run:
 	air
 

--- a/boilerplates/go-graphql-api/README.md
+++ b/boilerplates/go-graphql-api/README.md
@@ -24,8 +24,8 @@ Go + gqlgen の GraphQL API ボイラープレート。
 ## Quick Start
 
 ```bash
-# Install dependencies
-make install
+# Bootstrap dev env (deps + dev tools: air, golangci-lint)
+make setup
 
 # Run server
 make run
@@ -37,8 +37,8 @@ open http://localhost:8080/
 ## Development (Hot Reload)
 
 ```bash
-# Install dependencies + air (once)
-make install
+# Install deps + dev tools (air, golangci-lint) (once)
+make setup
 
 # Run with hot reload
 make run
@@ -50,7 +50,8 @@ Air watches `.go` files and automatically rebuilds/restarts the server on change
 
 ```bash
 make help           # Show all commands
-make install        # Download dependencies and dev tools (air)
+make install        # Download dependencies (go modules only)
+make setup          # Bootstrap dev env: deps + dev tools (air, golangci-lint)
 make build          # Build the binary
 make run            # Run the server with hot reload (air)
 make run-bare       # Run the server without hot reload

--- a/boilerplates/go-grpc-api/Makefile
+++ b/boilerplates/go-grpc-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean generate help
+.PHONY: install setup build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean generate help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -8,11 +8,20 @@ BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 50051
+# golangci-lint version installed by `make setup`. Keep in sync with CI
+# (.github/workflows/go-ci.yml).
+GOLANGCI_VERSION := v2.11.2
 
-## install: Download dependencies and dev tools
+## install: Download dependencies (go modules only)
 install:
 	go mod download
+
+## setup: Bootstrap dev env — deps (install) + dev tools (air, golangci-lint)
+setup: install
 	go install github.com/air-verse/air@latest
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b "$$(go env GOPATH)/bin" $(GOLANGCI_VERSION)
 
 ## generate: Generate protobuf code using buf
 generate:
@@ -22,7 +31,7 @@ generate:
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server with hot reload (requires air; installed by `make install`)
+## run: Run the server with hot reload (requires air; installed by `make setup`)
 run:
 	air
 

--- a/boilerplates/go-grpc-api/README.md
+++ b/boilerplates/go-grpc-api/README.md
@@ -61,8 +61,8 @@ go-grpc-api/
 ## Quick Start
 
 ```bash
-# Install dependencies
-make install
+# Bootstrap dev env (deps + dev tools: air, golangci-lint)
+make setup
 
 # Generate protobuf code
 make generate
@@ -74,8 +74,8 @@ make run
 ## Development (Hot Reload)
 
 ```bash
-# Install dependencies + air (once)
-make install
+# Install deps + dev tools (air, golangci-lint) (once)
+make setup
 
 # Run with hot reload
 make run
@@ -86,7 +86,8 @@ Air watches `.go` files and automatically rebuilds/restarts the server on change
 ## Available Commands
 
 ```bash
-make install        # Download dependencies and dev tools (air)
+make install        # Download dependencies (go modules only)
+make setup          # Bootstrap dev env: deps + dev tools (air, golangci-lint)
 make generate       # Generate protobuf code
 make build          # Build the binary
 make run            # Run the server with hot reload (air)

--- a/boilerplates/go-react-admin/Makefile
+++ b/boilerplates/go-react-admin/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build build-frontend compose-ui embed-dist run run-binary run-server run-frontend stop status \
+.PHONY: install setup build build-frontend compose-ui embed-dist run run-binary run-server run-frontend stop status \
   lint lint-frontend lint-fix format format-check \
   test test-frontend test-cov test-watch coverage \
   check ci clean help
@@ -15,6 +15,9 @@ FRONTEND_DIR := frontend
 # walking into frontend/node_modules, where vendored packages (e.g. flatted's
 # golang sample) would otherwise show up as 0%-covered and skew coverage.
 GO_PKGS := ./cmd/... ./internal/...
+# golangci-lint version installed by `make setup`. Keep in sync with CI
+# (.github/workflows/go-react-admin.yml).
+GOLANGCI_VERSION := v2.11.2
 
 # shared-react-ui: composed in-place from the sibling repo dir during local dev.
 # Outside the monorepo (after scaffold) the source dir is absent and the
@@ -41,6 +44,13 @@ compose-ui:
 install: compose-ui
 	go mod download
 	@if [ -d $(FRONTEND_DIR) ]; then cd $(FRONTEND_DIR) && npm ci; fi
+
+## setup: Bootstrap dev env — deps (install) + dev tools (air, golangci-lint)
+setup: install
+	go install github.com/air-verse/air@latest
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b "$$(go env GOPATH)/bin" $(GOLANGCI_VERSION)
 
 ## build-frontend: Build the React admin console into internal/static/dist
 build-frontend: compose-ui

--- a/boilerplates/go-react-admin/README.md
+++ b/boilerplates/go-react-admin/README.md
@@ -97,14 +97,14 @@ materialize する。これにより scaffold 後のプロジェクトは shared
 
 - Go 1.25+
 - Node.js（`frontend/.node-version` に従う）
-- [air](https://github.com/cosmtrek/air)（`make run` のみで使用）
-- [golangci-lint](https://golangci-lint.run/) v2.11+
+- [air](https://github.com/cosmtrek/air) と [golangci-lint](https://golangci-lint.run/) v2.11+
+  （いずれも `make setup` で導入）
 
 ## Quick start
 
 ```bash
-# Install: shared UI/admin を compose し、go mod download + npm ci
-make install
+# Bootstrap: install（shared UI/admin compose + go mod download + npm ci）+ 開発ツール（air, golangci-lint）
+make setup
 
 # Build: vite build -> internal/static/dist/、go build で dist/ を埋め込み
 make build
@@ -129,6 +129,7 @@ make stop
 
 ```bash
 make install         # compose-ui + go mod download + npm ci
+make setup           # install + 開発ツール（air, golangci-lint）
 make compose-ui      # shared-react-ui の ui/admin を frontend/ に materialize（monorepo 外では no-op）
 make build-frontend  # vite build -> internal/static/dist/
 make build           # build-frontend + go build（単一バイナリ）

--- a/boilerplates/go-react-spa/Makefile
+++ b/boilerplates/go-react-spa/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build build-frontend run run-binary run-server run-frontend stop status \
+.PHONY: install setup build build-frontend run run-binary run-server run-frontend stop status \
 	compose compose-clean verify \
 	lint lint-frontend lint-fix format format-check \
 	test test-frontend test-cov test-watch coverage \
@@ -19,11 +19,21 @@ OVERLAY_DIR := frontend.overlay
 FRONTEND_DIR := frontend
 COMPOSED_MARKER := $(FRONTEND_DIR)/.composed
 PACKAGE_NAME := go-react-spa-frontend
+# golangci-lint version installed by `make setup`. Keep in sync with CI
+# (.github/workflows/go-react-spa.yml).
+GOLANGCI_VERSION := v2.11.2
 
 ## install: Compose frontend, then install Go modules and frontend deps
 install: compose
 	go mod download
 	cd $(FRONTEND_DIR) && npm ci
+
+## setup: Bootstrap dev env — deps (install) + dev tools (air, golangci-lint)
+setup: install
+	go install github.com/air-verse/air@latest
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b "$$(go env GOPATH)/bin" $(GOLANGCI_VERSION)
 
 ## compose: Materialize frontend/ from base template + overlay
 compose: $(COMPOSED_MARKER)

--- a/boilerplates/go-react-spa/README.md
+++ b/boilerplates/go-react-spa/README.md
@@ -60,14 +60,14 @@ default tag set so the bundle is embedded into the produced binary.
 
 - Go 1.25+
 - Node.js (matches `react-spa/.node-version`)
-- [air](https://github.com/cosmtrek/air) (only for `make run`)
-- [golangci-lint](https://golangci-lint.run/) v2.11+
+- [air](https://github.com/cosmtrek/air) and [golangci-lint](https://golangci-lint.run/) v2.11+
+  (both installed by `make setup`)
 
 ## Quick start
 
 ```bash
-# Install: composes frontend/ from base+overlay, then `go mod download` + `npm ci`
-make install
+# Bootstrap: install (compose + `go mod download` + `npm ci`) + dev tools (air, golangci-lint)
+make setup
 
 # Build: `vite build` -> internal/static/dist/, then `go build` embedding the bundle
 make build
@@ -92,6 +92,7 @@ make stop
 
 ```bash
 make install         # compose + download Go modules + npm ci
+make setup           # install + dev tools (air, golangci-lint)
 make compose         # materialize frontend/ from base + overlay
 make compose-clean   # remove frontend/
 make build-frontend  # vite build -> internal/static/dist/

--- a/boilerplates/go-rest-api/Makefile
+++ b/boilerplates/go-rest-api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean help
+.PHONY: install setup build run run-bare stop status lint test test-cov check ci migrate migrate-diff migrate-apply migrate-hash clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -8,17 +8,26 @@ BINARY_NAME := server
 BIN_DIR := bin
 COVERAGE_FILE := coverage.out
 PORT ?= 8080
+# golangci-lint version installed by `make setup`. Keep in sync with CI
+# (.github/workflows/go-ci.yml).
+GOLANGCI_VERSION := v2.11.2
 
-## install: Download dependencies and dev tools
+## install: Download dependencies (go modules only)
 install:
 	go mod download
+
+## setup: Bootstrap dev env — deps (install) + dev tools (air, golangci-lint)
+setup: install
 	go install github.com/air-verse/air@latest
+	@command -v golangci-lint >/dev/null 2>&1 || \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+		| sh -s -- -b "$$(go env GOPATH)/bin" $(GOLANGCI_VERSION)
 
 ## build: Build the binary
 build:
 	go build -o $(BIN_DIR)/$(BINARY_NAME) ./cmd/server
 
-## run: Run the server with hot reload (requires air; installed by `make install`)
+## run: Run the server with hot reload (requires air; installed by `make setup`)
 run:
 	air
 

--- a/boilerplates/go-rest-api/README.md
+++ b/boilerplates/go-rest-api/README.md
@@ -24,8 +24,8 @@ Go + Gin + GORM + JWT の Batteries Included な REST API ボイラープレー�
 ## Quick Start
 
 ```bash
-# Install dependencies
-make install
+# Bootstrap dev env (deps + dev tools: air, golangci-lint)
+make setup
 
 # Run server (auto-migrates DB on startup)
 make run
@@ -47,10 +47,10 @@ curl http://localhost:10080/api/v1/users \
 
 ## Development (Hot Reload)
 
-`make install` installs `air` for hot reload, then `make run` starts the server with reload enabled.
+`make setup` installs dev tools (`air`, `golangci-lint`), then `make run` starts the server with reload enabled.
 
 ```bash
-make install
+make setup
 make run
 ```
 
@@ -58,7 +58,8 @@ make run
 
 ```bash
 make help            # Show all commands
-make install         # Download dependencies and dev tools (air)
+make install         # Download dependencies (go modules only)
+make setup           # Bootstrap dev env: deps + dev tools (air, golangci-lint)
 make build           # Build the binary
 make run             # Run the server with hot reload (air)
 make run-bare        # Run the server without hot reload

--- a/scripts/scaffold/templates/README.md.tmpl
+++ b/scripts/scaffold/templates/README.md.tmpl
@@ -1,6 +1,6 @@
 # {{NAME}}
 
-Scaffolded from [my-boilerplate/{{TEMPLATE}}](https://github.com/rengotaku/my-boilerplate/tree/main/{{TEMPLATE}}).
+Scaffolded from [my-boilerplate/{{TEMPLATE}}](https://github.com/rengotaku/my-boilerplate/tree/main/boilerplates/{{TEMPLATE}}).
 
 ## Getting Started
 


### PR DESCRIPTION
## 概要

fresh clone 後に `make run`（`air`）/ `make lint`（`golangci-lint`）が command not found で詰まる問題を解消する。依存取得（install）と開発ツール導入（setup）を分離し、`.air.toml` を持つ全 Go テンプレに一貫した `make setup` を追加した。

## 関連 Issue

Closes: #245

## Affects

なし

## 変更タイプ

- [x] feat: 新機能
- [ ] fix / refactor / perf / chore / docs / test / schema

## 動作確認手順（ローカル起動）

```bash
for t in go-rest-api go-graphql-api go-grpc-api go-react-spa go-react-admin; do
  make -C boilerplates/$t -n setup       # air + golangci-lint(v2.11.2) が展開される
  make -C boilerplates/$t help | grep setup
done
```

### 動作確認シナリオ

- [x] 全5テンプレで `make -n setup` が air + golangci-lint(v2.11.2) を出力
- [x] `make help` に `setup` が表示される

## テスト

- [x] `make ci` PASS（CI の per-template / scaffold-verify で検証）
- [ ] 新規/変更コードに対するユニットテストを追加した（N/A: Makefile/README の配線）

## チェックリスト

- [x] `Closes:` を使用（単独 issue）
- [x] README 更新済み（Quick start / Development / Commands を make setup 起点に）
- [x] 機密情報なし / Conventional Commits / base=main

## 補足 / レビュー観点

- `install` を依存取得のみに統一。go-rest-api / go-graphql-api / go-grpc-api は従来 `install` が `air` も入れていたが、`setup` へ移動（issue の install=deps / setup=deps+tools 方針に合わせる）。
- `golangci-lint` バージョンは各 Makefile の `GOLANGCI_VERSION`（v2.11.2）に変数化、CI と揃えるコメント付き。
- 併せて scaffold 用 README テンプレの GitHub リンクを `boilerplates/<name>` に修正（#229 のリンク追従漏れ）。