### PR TITLE
feat(go-cli): cobra 規約と DisableFlagParsing 非依存の推奨スケルトンを追加 (#234)

### DIFF
--- a/boilerplates/go-cli/README.md
+++ b/boilerplates/go-cli/README.md
@@ -56,6 +56,8 @@ make build
 ./bin/mycli hello Alice              # Hello, Alice!
 ./bin/mycli version                  # mycli version dev
 ./bin/mycli config                   # Print loaded config
+./bin/mycli note "Buy milk" --tags home,errand --priority 3
+./bin/mycli note -- "--dry-run needs documenting"  # leading-dash title via --
 ./bin/mycli --help                   # Show help
 
 # Logging is configured via env vars (slog)
@@ -70,13 +72,36 @@ APP_ENV=production ./bin/mycli hello # JSON handler (structured logs)
 | `APP_ENV`   | `development` | `production` で slog の JSON ハンドラに切り替わる    |
 | `LOG_LEVEL` | `info`        | `debug` / `info` / `warn` / `error` を受け付ける     |
 
+## Cobra Conventions
+
+cobra コマンドを追加するときの規約。`cmd/note.go` がこの規約に沿った推奨スケルトン（自由文の位置引数 + 本物のフラグ + `--help`/`--` がそのまま効く）。
+
+- **`DisableFlagParsing: true` は具体的な理由がない限り使わない。** これを付けると cobra/pflag 標準の `--help`/`-h` 処理と `--`（引数終端）サポートを**同時に捨てる**ため、各コマンドが pflag の劣化版を手書きする羽目になる。典型的な事故: `mycli add --help` が usage を出さず `--help` をタイトルとして書き込む。やむを得ず使う場合は理由を `// DisableFlagParsing:` コメントで明記する。
+- **オプションは pflag の本物のフラグとして定義する**（`cmd.Flags().StringVar(...)` 等）。手書きパーサで再実装しない。typo は `unknown flag` で弾かれる。
+- **`-` 始まりになりうる自由文は `--`（引数終端）の後ろに渡す。** pflag が flag 扱いするのはトークン先頭が `-` のときだけなので、`--` が標準・ゼロコストの手段。help / flag / `--` の解釈は cobra に任せる。
+
+### 自由文を渡すラッパー規約
+
+シェル関数等でコマンドをラップする場合、末尾の自由文引数の前に `--` を自動挿入すると「flag/help は cobra」「自由文は常に安全」を両立できる:
+
+```bash
+mycli-note() {
+  # 末尾の自由文（タイトル）は必ず `--` の後ろへ
+  command mycli note "${@:1:$#-1}" -- "${@: -1}"
+}
+```
+
+回帰防止として `cmd/note_test.go` に `note --help` が exit 0 で usage を返すスモークテスト、`--` 経由の `-` 始まりタイトル、未知フラグ reject のテストを同梱している。
+
 ## Project Structure
 
 ```
 go-cli/
 ├── cmd/
 │   ├── root.go            # Cobra root command (config + logger をロード)
-│   └── root_test.go
+│   ├── root_test.go
+│   ├── note.go            # 推奨スケルトン + cobra 規約（DisableFlagParsing を使わない）
+│   └── note_test.go       # --help / -- / unknown-flag のスモークテスト
 ├── internal/
 │   ├── config/            # envconfig ベースの設定ローダー
 │   ├── logger/            # slog ベースのロガー

--- a/boilerplates/go-cli/cmd/note.go
+++ b/boilerplates/go-cli/cmd/note.go
@@ -1,0 +1,69 @@
+package cmd
+
+// Cobra command conventions (read before adding commands)
+//
+// This file is the recommended skeleton for new subcommands. Follow these
+// rules so `--help`, flag parsing, and `--` (end-of-options) keep working —
+// they are exactly what you lose the moment you reach for DisableFlagParsing.
+//
+//  1. Do NOT set `DisableFlagParsing: true` without a concrete, documented
+//     reason. It silently disables cobra/pflag's built-in `--help`/`-h`
+//     handling AND the standard `--` argument terminator, forcing every
+//     command to re-implement a worse parser by hand. The classic failure:
+//     `mytool add --help` writes a record titled "--help" instead of printing
+//     usage. If you truly must disable it, write a `// DisableFlagParsing:`
+//     comment explaining why.
+//  2. Define options as real pflag flags (cmd.Flags().StringVar(...)), never a
+//     hand-rolled scan of args. Typos then fail loudly as `unknown flag`.
+//  3. Free-form text that may start with `-` is passed by the caller AFTER a
+//     `--` terminator: `mycli note -- "--dry-run is broken"`. pflag treats a
+//     token as a flag only when it starts with `-`, so `--` is the standard,
+//     zero-cost way to pass leading-dash text. Let cobra own help/flag/`--`.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// noteCmd is the canonical "safe" subcommand: a free-text positional argument
+// plus real flags, with no DisableFlagParsing. `--help` works automatically,
+// unknown flags are rejected, and a leading-dash title is passed via `--`.
+var noteCmd = &cobra.Command{
+	Use:   "note TITLE [--tags t1,t2] [--priority N]",
+	Short: "Record a note (skeleton showing safe flag handling)",
+	Long: "Record a note.\n\n" +
+		"Demonstrates the recommended cobra pattern: real flags, automatic --help,\n" +
+		"and `--` for titles that start with a dash, e.g.:\n" +
+		"  mycli note -- \"--dry-run needs documenting\"",
+	Args: cobra.ExactArgs(1), // TITLE
+	RunE: func(cmd *cobra.Command, args []string) error {
+		title := args[0]
+		tags, err := cmd.Flags().GetStringSlice("tags")
+		if err != nil {
+			return err
+		}
+		priority, err := cmd.Flags().GetInt("priority")
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		if _, err := fmt.Fprintf(out, "note: %s\n", title); err != nil {
+			return err
+		}
+		if len(tags) > 0 {
+			if _, err := fmt.Fprintf(out, "tags: %s\n", strings.Join(tags, ",")); err != nil {
+				return err
+			}
+		}
+		_, err = fmt.Fprintf(out, "priority: %d\n", priority)
+		return err
+	},
+}
+
+func init() {
+	noteCmd.Flags().StringSlice("tags", nil, "comma-separated tags")
+	noteCmd.Flags().Int("priority", 0, "priority (higher = more urgent)")
+	rootCmd.AddCommand(noteCmd)
+}

--- a/boilerplates/go-cli/cmd/note_test.go
+++ b/boilerplates/go-cli/cmd/note_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoteCommand_FlagsParsed(t *testing.T) {
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("LOG_LEVEL", "info")
+
+	out, _, err := runRoot(t, "note", "Buy milk", "--tags", "home,errand", "--priority", "3")
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "note: Buy milk")
+	assert.Contains(t, out, "tags: home,errand")
+	assert.Contains(t, out, "priority: 3")
+}
+
+// Regression for the DisableFlagParsing trap: `--help` must print usage and
+// exit 0, never be swallowed as the TITLE argument.
+func TestNoteCommand_HelpIsHandled(t *testing.T) {
+	out, _, err := runRoot(t, "note", "--help")
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "Usage:")
+	assert.Contains(t, out, "note TITLE")
+}
+
+// A leading-dash title is passed literally after the `--` terminator instead
+// of being misread as a flag.
+func TestNoteCommand_DashDashPassesLiteralTitle(t *testing.T) {
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("LOG_LEVEL", "info")
+
+	out, _, err := runRoot(t, "note", "--", "--dry-run needs documenting")
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "note: --dry-run needs documenting")
+}
+
+// Unknown flags fail loudly rather than being silently accepted as input.
+func TestNoteCommand_UnknownFlagRejected(t *testing.T) {
+	_, _, err := runRoot(t, "note", "Title", "--bogus", "x")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown flag")
+}

--- a/boilerplates/go-cli/cmd/root_test.go
+++ b/boilerplates/go-cli/cmd/root_test.go
@@ -6,9 +6,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func resetHelpFlag(c *cobra.Command) {
+	if f := c.Flags().Lookup("help"); f != nil {
+		_ = f.Value.Set("false")
+		f.Changed = false
+	}
+}
 
 func runRoot(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
@@ -20,6 +28,14 @@ func runRoot(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Cleanup(func() {
 		rootCmd.SetArgs(nil)
 		logOut = nil
+		// cobra commands are package-level singletons, so the auto-added
+		// `help` flag retains its value across Execute calls. Reset it (on the
+		// root and every subcommand) so a `--help` run can't leak into the
+		// next test and make it print usage instead of running.
+		resetHelpFlag(rootCmd)
+		for _, c := range rootCmd.Commands() {
+			resetHelpFlag(c)
+		}
 	})
 	err = rootCmd.ExecuteContext(context.Background())
 	return outBuf.String(), errBuf.String(), err


### PR DESCRIPTION
## 概要

`DisableFlagParsing: true` の安易な利用で `<cmd> --help` が破壊的操作になる罠（`--help` が引数として書き込まれる）を、テンプレ側で最初から踏ませないための規約・推奨スケルトン・回帰テストを go-cli に追加する。

## 関連 Issue

Closes: #234

## Affects

なし

## 変更タイプ

- [x] feat: 新機能 / documentation

## 動作確認手順（ローカル起動）

```bash
cd boilerplates/go-cli
go test ./...                 # note の --help / -- / unknown-flag テスト含め PASS
go vet ./... && gofmt -l cmd/ # clean
golangci-lint run             # 0 issues
```

### 動作確認シナリオ

- [x] `note --help` が exit 0 で usage を返す（破壊的書き込みにならない）
- [x] `note -- "--dry-run ..."` で `-` 始まりタイトルがリテラルに渡る
- [x] `note --bogus x` が `unknown flag` で reject される

## テスト

- [x] `go test ./...` PASS（cmd スモークテスト追加）
- [x] 新規テストを追加した（cmd/note_test.go）

## チェックリスト

- [x] `Closes:` / 機密情報なし / Conventional Commits / base=main
- [x] README 更新（Cobra Conventions 節 + 自由文ラッパー規約）

## 受け入れ条件（issue DoD）

- [x] cobra 使用規約を明記（README「Cobra Conventions」+ cmd/note.go 冒頭 doc コメント。doc コメントは scaffold 後のプロジェクトにも残る）
- [x] DisableFlagParsing を使わない推奨スケルトン（cmd/note.go）
- [x] 自由文を `--` 経由で渡すラッパー規約を文書化（README）
- [x] （任意）`--help` スモークテスト雛形（cmd/note_test.go）

## 補足 / レビュー観点

- 規約はテンプレ利用者にも届くよう、README だけでなく `cmd/note.go` の冒頭 doc コメントにも記載（README は scaffold 時に汎用テンプレで上書きされるが、`.go` ソースは残るため）。
- `root_test.go` に cobra シングルトンの `help` フラグをテスト間でリセットする処理を追加（`--help` 実行が後続テストへ漏れるのを防止）。